### PR TITLE
fix compilation error on some compilers

### DIFF
--- a/pdf_viewer/ui.h
+++ b/pdf_viewer/ui.h
@@ -232,23 +232,22 @@ public:
 	FilteredTreeSelect(QStandardItemModel* item_model,
 		std::function<void(const std::vector<int>&)> on_done,
 		QWidget* parent,
-		std::vector<int> selected_index) : BaseSelectorWidget(item_model, parent),
+		std::vector<int> selected_index) : BaseSelectorWidget<T, QTreeView, QSortFilterProxyModel>(item_model, parent),
 		on_done(on_done)
 	{
-
 		auto index = QModelIndex();
 		for (auto i : selected_index) {
-			index = proxy_model->index(i, 0, index);
+			index = this->proxy_model->index(i, 0, index);
 		}
 
-		dynamic_cast<QTreeView*>(get_view())->setCurrentIndex(index);
+		dynamic_cast<QTreeView*>(this->get_view())->setCurrentIndex(index);
 
 	}
 
 	void on_select(const QModelIndex& index) {
-		hide();
-		parentWidget()->setFocus();
-		auto source_index = proxy_model->mapToSource(index);
+		this->hide();
+		this->parentWidget()->setFocus();
+		auto source_index = this->proxy_model->mapToSource(index);
 		std::vector<int> indices;
 		while (source_index != QModelIndex()) {
 			indices.push_back(source_index.row());
@@ -292,7 +291,7 @@ public:
 		QStringList string_list = QStringList::fromVector(q_string_list);
 
 		string_list_model = new QStringListModel(string_list);
-		proxy_model->setSourceModel(string_list_model);
+		this->proxy_model->setSourceModel(string_list_model);
 
 	}
 
@@ -300,15 +299,15 @@ public:
 		if (on_delete_function) {
 			on_delete_function(&values[source_index.row()]);
 			int delete_row = selected_index.row();
-			proxy_model->removeRow(selected_index.row());
+			this->proxy_model->removeRow(selected_index.row());
 			values.erase(values.begin() + source_index.row());
 		}
 	}
 
 	void on_select(const QModelIndex& index) {
-		hide();
-		parentWidget()->setFocus();
-		auto source_index = proxy_model->mapToSource(index);
+		this->hide();
+		this->parentWidget()->setFocus();
+		auto source_index = this->proxy_model->mapToSource(index);
 		on_done(&values[source_index.row()]);
 	}
 };


### PR DESCRIPTION
I was getting the following compilation errors since the recent UI code refactor 
```
In file included from pdf_viewer/document_view.h:25,
                 from pdf_viewer/document_view.cpp:1:
pdf_viewer/ui.h: In constructor ‘FilteredTreeSelect<T>::FilteredTreeSelect(QStandardItemModel*, std::function<void(const std::vector<int, std::allocator<int> >&)>, QWidget*, std::vector<int, std::allocator<int> >)’:
pdf_viewer/ui.h:235:52: error: class ‘FilteredTreeSelect<T>’ does not have any field named ‘BaseSelectorWidget’
  235 |                 std::vector<int> selected_index) : BaseSelectorWidget(item_model, parent),
      |                                                    ^~~~~~~~~~~~~~~~~~
pdf_viewer/ui.h:241:33: error: ‘proxy_model’ was not declared in this scope
  241 |                         index = proxy_model->index(i, 0, index);
      |                                 ^~~~~~~~~~~
pdf_viewer/ui.h:244:42: error: there are no arguments to ‘get_view’ that depend on a template parameter, so a declaration of ‘get_view’ must be available [-fpermissive]
  244 |                 dynamic_cast<QTreeView*>(get_view())->setCurrentIndex(index);
      |                                          ^~~~~~~~
pdf_viewer/ui.h:244:42: note: (if you use ‘-fpermissive’, G++ will accept your code, but allowing the use of an undeclared name is deprecated)
pdf_viewer/ui.h: In member function ‘void FilteredTreeSelect<T>::on_select(const QModelIndex&)’:
pdf_viewer/ui.h:249:17: error: there are no arguments to ‘hide’ that depend on a template parameter, so a declaration of ‘hide’ must be available [-fpermissive]
  249 |                 hide();
      |                 ^~~~
pdf_viewer/ui.h:250:17: error: there are no arguments to ‘parentWidget’ that depend on a template parameter, so a declaration of ‘parentWidget’ must be available [-fpermissive]
  250 |                 parentWidget()->setFocus();
      |                 ^~~~~~~~~~~~
pdf_viewer/ui.h:251:37: error: ‘proxy_model’ was not declared in this scope
  251 |                 auto source_index = proxy_model->mapToSource(index);
      |                                     ^~~~~~~~~~~
In file included from pdf_viewer/document_view.h:25,
                 from pdf_viewer/document_view.cpp:1:
pdf_viewer/ui.h: In constructor ‘FilteredSelectWindowClass<T>::FilteredSelectWindowClass(std::vector<std::__cxx11::basic_string<wchar_t> >, std::vector<T>, std::function<void(T*)>, QWidget*, std::function<void(T*)>)’:
pdf_viewer/ui.h:295:17: error: ‘proxy_model’ was not declared in this scope
  295 |                 proxy_model->setSourceModel(string_list_model);
      |                 ^~~~~~~~~~~
pdf_viewer/ui.h: In member function ‘virtual void FilteredSelectWindowClass<T>::on_delete(const QModelIndex&, const QModelIndex&)’:
pdf_viewer/ui.h:303:25: error: ‘proxy_model’ was not declared in this scope
  303 |                         proxy_model->removeRow(selected_index.row());
      |                         ^~~~~~~~~~~
pdf_viewer/ui.h: In member function ‘void FilteredSelectWindowClass<T>::on_select(const QModelIndex&)’:
pdf_viewer/ui.h:309:17: error: there are no arguments to ‘hide’ that depend on a template parameter, so a declaration of ‘hide’ must be available [-fpermissive]
  309 |                 hide();
      |                 ^~~~
pdf_viewer/ui.h:310:17: error: there are no arguments to ‘parentWidget’ that depend on a template parameter, so a declaration of ‘parentWidget’ must be available [-fpermissive]
  310 |                 parentWidget()->setFocus();
      |                 ^~~~~~~~~~~~
pdf_viewer/ui.h:311:37: error: ‘proxy_model’ was not declared in this scope
  311 |                 auto source_index = proxy_model->mapToSource(index);
      |                                     ^~~~~~~~~~~
```

Proposed fix, based on https://isocpp.org/wiki/faq/templates#nondependent-name-lookup-members
but I'm not a C++ programmer, maybe it's bad style