### PR TITLE
Add support for `QEvent::FileOpen` (#115)

### DIFF
--- a/pdf_viewer/OpenWithApplication.h
+++ b/pdf_viewer/OpenWithApplication.h
@@ -1,0 +1,22 @@
+#ifndef OPEN_WITH_APP_H
+#define OPEN_WITH_APP_H
+
+#include <qapplication.h>
+
+class OpenWithApplication : public QApplication
+{
+	Q_OBJECT
+public:
+	QString file_name;
+    OpenWithApplication(int &argc, char **argv)
+        : QApplication(argc, argv)
+    {
+    }
+signals:
+    void fileReady(QString fn);
+
+protected:
+    bool event(QEvent *event) override;
+};
+
+#endif // OPEN_WITH_APP_H

--- a/pdf_viewer_build_config.pro
+++ b/pdf_viewer_build_config.pro
@@ -37,7 +37,8 @@ HEADERS += pdf_viewer/book.h \
            pdf_viewer/utf8/unchecked.h \
            pdf_viewer/synctex/synctex_parser.h \
            pdf_viewer/synctex/synctex_parser_utils.h \
-           pdf_viewer/RunGuard.h
+           pdf_viewer/RunGuard.h \
+           pdf_viewer/OpenWithApplication.h
 
 SOURCES += pdf_viewer/book.cpp \
            pdf_viewer/config.cpp \
@@ -92,5 +93,6 @@ mac {
     CONFIG+=sdk_no_version_check
     QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.15
     ICON = pdf_viewer\icon2.ico
+    QMAKE_INFO_PLIST = resources/Info.plist
 }
 

--- a/resources/Info.plist
+++ b/resources/Info.plist
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleExecutable</key>
+	<string>sioyek</string>
+	<key>CFBundleIconFile</key>
+	<string>icon2.ico</string>
+	<key>CFBundleIdentifier</key>
+	<string>info.sioyek.sioyek</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.1.0</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>10.15</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>NSSupportsAutomaticGraphicsSwitching</key>
+	<true/>
+	<key>CFBundleDocumentTypes</key>
+    <array>
+        <dict>
+			<key>CFBundleTypeName</key>
+			<string>PDF Document</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Alternate</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.adobe.pdf</string>
+			</array>
+		</dict>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
This PR adds necessary connections to support macOS's "open with" feature. It fixes the second issue in #115.

Specifically, sioyek now supports the following features. I attached some images to demonstrate them.
- drag-and-drop style file loading
- "open with" shown in macOS's context menu
- smooth integration with [Zotero](https://www.zotero.org/).

 Disclaimer: C++ and Qt are entirely new to me. This implementation may not comply with sioyek's coding convention, so I appreciate any feedback on the PR.

References:

- https://doc.qt.io/qt-5/qfileopenevent.html
- https://doc.qt.io/qt-5/qmake-variable-reference.html#qmake-info-plist
- https://stackoverflow.com/questions/26849866/unable-to-open-file-with-qt-app-on-mac

![Screen-Recording-2022-04-02-at-7 59 20-PM](https://user-images.githubusercontent.com/12794966/161409613-276b0764-6c3b-45b8-bec7-e91a137bad2b.gif)
![Screen-Recording-2022-04-02-at-7 57 45-PM](https://user-images.githubusercontent.com/12794966/161409619-c7cf1148-d738-4e74-8117-7d9019528180.gif)

For anyone who'd like to test, here's the artifact: https://github.com/mistzzt/sioyek/actions/runs/2083894567

