### PR TITLE
Fix document not re-rendered & code cleanup

### DIFF
--- a/pdf_viewer/OpenWithApplication.cpp
+++ b/pdf_viewer/OpenWithApplication.cpp
@@ -1,0 +1,10 @@
+#include <OpenWithApplication.h>
+
+bool OpenWithApplication::event(QEvent *event) {
+	if (event->type() == QEvent::FileOpen) {
+		QFileOpenEvent *openEvent = static_cast<QFileOpenEvent *>(event);
+		emit file_ready(openEvent->file());
+	}
+
+	return QApplication::event(event);
+}

--- a/pdf_viewer/OpenWithApplication.h
+++ b/pdf_viewer/OpenWithApplication.h
@@ -1,19 +1,19 @@
 #ifndef OPEN_WITH_APP_H
 #define OPEN_WITH_APP_H
 
-#include <qapplication.h>
+#include <QApplication>
+#include <QFileOpenEvent>
 
 class OpenWithApplication : public QApplication
 {
 	Q_OBJECT
 public:
-	QString file_name;
     OpenWithApplication(int &argc, char **argv)
         : QApplication(argc, argv)
     {
     }
 signals:
-    void fileReady(QString fn);
+    void file_ready(const QString& file_name);
 
 protected:
     bool event(QEvent *event) override;

--- a/pdf_viewer/main.cpp
+++ b/pdf_viewer/main.cpp
@@ -88,7 +88,7 @@ std::string LOG_FILE_NAME = "sioyek_log.txt";
 std::ofstream LOG_FILE;
 int FONT_SIZE = -1;
 int STATUS_BAR_FONT_SIZE = -1;
-std::string APPLICATION_VERSION = "1.3.0";
+std::string APPLICATION_VERSION = "1.2.0";
 float BACKGROUND_COLOR[3] = { 1.0f, 1.0f, 1.0f };
 float DARK_MODE_BACKGROUND_COLOR[3] = { 0.0f, 0.0f, 0.0f };
 float CUSTOM_BACKGROUND_COLOR[3] = { 1.0f, 1.0f, 1.0f };

--- a/pdf_viewer/main.cpp
+++ b/pdf_viewer/main.cpp
@@ -358,17 +358,6 @@ void add_paths_to_file_system_watcher(QFileSystemWatcher& watcher, const Path& d
     }
 }
 
-bool OpenWithApplication::event(QEvent *event)
-{
-	if (event->type() == QEvent::FileOpen) {
-		QFileOpenEvent *openEvent = static_cast<QFileOpenEvent *>(event);
-		file_name = openEvent->file();
-		emit fileReady(file_name); //  the file is ready
-	}
-
-	return QApplication::event(event);
-}
-
 int main(int argc, char* args[]) {
 
 	QSurfaceFormat format;
@@ -501,8 +490,8 @@ int main(int argc, char* args[]) {
 	main_widget.handle_args(app.arguments());
 
 	// load input file from `QFileOpenEvent` for macOS drag and drop & "open with"
-	QObject::connect(&app, &OpenWithApplication::fileReady, [&main_widget](QString fileName) {
-		main_widget.open_document(fileName.toStdWString());
+	QObject::connect(&app, &OpenWithApplication::file_ready, [&main_widget](const QString& file_name) {
+		main_widget.handle_args(QStringList() << file_name << file_name);
 	});
 
     // live reload the config files

--- a/pdf_viewer/main.cpp
+++ b/pdf_viewer/main.cpp
@@ -88,7 +88,7 @@ std::string LOG_FILE_NAME = "sioyek_log.txt";
 std::ofstream LOG_FILE;
 int FONT_SIZE = -1;
 int STATUS_BAR_FONT_SIZE = -1;
-std::string APPLICATION_VERSION = "1.1.0";
+std::string APPLICATION_VERSION = "1.3.0";
 float BACKGROUND_COLOR[3] = { 1.0f, 1.0f, 1.0f };
 float DARK_MODE_BACKGROUND_COLOR[3] = { 0.0f, 0.0f, 0.0f };
 float CUSTOM_BACKGROUND_COLOR[3] = { 1.0f, 1.0f, 1.0f };

--- a/pdf_viewer_build_config.pro
+++ b/pdf_viewer_build_config.pro
@@ -56,8 +56,9 @@ SOURCES += pdf_viewer/book.cpp \
            pdf_viewer/path.cpp \
            pdf_viewer/utils.cpp \
            pdf_viewer/synctex/synctex_parser.c \
-           pdf_viewer/synctex/synctex_parser_utils.c\
-           pdf_viewer/RunGuard.cpp
+           pdf_viewer/synctex/synctex_parser_utils.c \
+           pdf_viewer/RunGuard.cpp \
+           pdf_viewer/OpenWithApplication.cpp
 
 
 win32{

--- a/pdf_viewer_build_config.pro
+++ b/pdf_viewer_build_config.pro
@@ -1,6 +1,6 @@
 TEMPLATE = app
 TARGET = sioyek
-VERSION = 1.3.0
+VERSION = 1.2.0
 INCLUDEPATH += ./pdf_viewer\
               mupdf/include \
               zlib

--- a/pdf_viewer_build_config.pro
+++ b/pdf_viewer_build_config.pro
@@ -1,5 +1,6 @@
 TEMPLATE = app
 TARGET = sioyek
+VERSION = 1.3.0
 INCLUDEPATH += ./pdf_viewer\
               mupdf/include \
               zlib

--- a/resources/Info.plist
+++ b/resources/Info.plist
@@ -3,9 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleExecutable</key>
-	<string>sioyek</string>
+	<string>@EXECUTABLE@</string>
 	<key>CFBundleIconFile</key>
-	<string>icon2.ico</string>
+	<string>@ICON@</string>
 	<key>CFBundleIdentifier</key>
 	<string>info.sioyek.sioyek</string>
 	<key>CFBundlePackageType</key>
@@ -13,7 +13,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.0</string>
+	<string>@SHORT_VERSION@</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>10.15</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
This is a following up PR for #173.

* Fix inconsistent variable naming
* Move `OpenWithApplication` implementation out from `main.cpp`
* Add placeholder variables for `Info.plist`
* Fix the re-rendering issue