### PR TITLE
Filechooser fixes

### DIFF
--- a/pdf_viewer/ui.h
+++ b/pdf_viewer/ui.h
@@ -652,7 +652,7 @@ public:
 	void on_select(const QModelIndex& index) {
 		QString name = list_model->data(index).toString();
 		QChar sep = QDir::separator();
-		QString full_path = expand_home_dir(last_root + sep + name);
+		QString full_path = expand_home_dir((last_root.size() > 0) ? (last_root + sep + name) : name);
 
 		if (QFileInfo(full_path).isFile()) {
 			on_done(full_path.toStdWString());

--- a/pdf_viewer/utils.cpp
+++ b/pdf_viewer/utils.cpp
@@ -1616,7 +1616,7 @@ void check_for_updates(QWidget* parent, std::string current_version) {
 QString expand_home_dir(QString path) {
 	if (path.size() > 0) {
 		if (path.at(0) == '~') {
-			return QDir::homePath() + QDir::separator() + path.remove(0, 1);
+			return QDir::homePath() + QDir::separator() + path.remove(0, 2);
 		}
 	}
 	return path;


### PR DESCRIPTION
### Minor bug fixes in the embedded file selector:

- Typing ~/ in the text box and selecting a subdirectory no longer resolves the full path to /home/USERNAME//SUBDIRECTORY/ and inputs a single separator (in my case forward slash) instead, i.e. /home/USERNAME/SUBDIRECTORY/
- Selecting a subdirectory inside the root directory while the text box is empty no longer resolves the full path to /SUBDIRECTORY/  (which the subdirectory finder then interprets as a location in the _system's_ root / directory and displays nothing), and instead resolves to a relative path name, i.e. SUBDIRECTORY/