### PR TITLE
add mupdf link dependencies

### DIFF
--- a/pdf_viewer_build_config.pro
+++ b/pdf_viewer_build_config.pro
@@ -82,7 +82,7 @@ unix:!mac {
     } else {
         DEFINES += NON_PORTABLE
         DEFINES += LINUX_STANDARD_PATHS
-        LIBS += -ldl -lmupdf -lharfbuzz -lfreetype -ljbig2dec -ljpeg -lmujs -lopenjp2 -lz
+        LIBS += -ldl -lmupdf -lmupdf-third -lgumbo -lharfbuzz -lfreetype -ljbig2dec -ljpeg -lmujs -lopenjp2 -lz
     }
 
     isEmpty(PREFIX){


### PR DESCRIPTION
For building `sioyek` with system (ubuntu) package `libmupdf-dev`, we need add two additional dependencies.