### PR TITLE
Allow detached process

### DIFF
--- a/pdf_viewer/utils.cpp
+++ b/pdf_viewer/utils.cpp
@@ -817,12 +817,12 @@ void run_command(std::wstring command, QStringList parameters, bool wait){
 	}
 	//qparameters.append(QString::fromStdWString(parameters));
 
-	process->start(qcommand, qparameters);
 	if (wait) {
+		process->start(qcommand, qparameters);
 		process->waitForFinished();
 	}
 	else {
-		QObject::connect(process, SIGNAL(finished(int)), process, SLOT(deleteLater()));
+		process->startDetached(qcommand, qparameters);
 	}
 #endif
 


### PR DESCRIPTION
This will allow users to invoke interactive process in their scripts.
For example, people use `slurp` with `grim` to take an interactive regional screenshot; if in this case, the process `slurp` is not detached, then it will wait untill `sioyek` exits to execute itself.