### PR TITLE
Fix errors in command line help for forward search options

### DIFF
--- a/pdf_viewer/utils.cpp
+++ b/pdf_viewer/utils.cpp
@@ -1490,13 +1490,13 @@ QCommandLineParser* get_command_line_parser() {
 	QCommandLineOption command_option("execute-command", "The command to execute on running instance of sioyek", "execute-command");
 	parser->addOption(command_option);
 
-	QCommandLineOption forward_search_file_option("forward-search-file", "Perform forward search on file <file> must also include --forward-search-line to specify the line", "file");
+	QCommandLineOption forward_search_file_option("forward-search-file", "Perform forward search on file <file>. You must also include --forward-search-line to specify the line", "file");
 	parser->addOption(forward_search_file_option);
 
-	QCommandLineOption forward_search_line_option("forward-search-line", "Perform forward search on line <line> must also include --forward-search-file to specify the file", "file");
+	QCommandLineOption forward_search_line_option("forward-search-line", "Perform forward search on line <line>. You must also include --forward-search-file to specify the file", "line");
 	parser->addOption(forward_search_line_option);
 
-	QCommandLineOption forward_search_column_option("forward-search-column", "Perform forward search on column <column> must also include --forward-search-file to specify the file", "file");
+	QCommandLineOption forward_search_column_option("forward-search-column", "Perform forward search on column <column>. You must also include --forward-search-file to specify the file", "column");
 	parser->addOption(forward_search_column_option);
 
 	QCommandLineOption zoom_level_option("zoom", "Set zoom level to <zoom>.", "zoom");


### PR DESCRIPTION
For the forward-search-* family of options, this patch fixes a grammatical error I found confusing. In addition, it fixes the value name of two of the forward search options so that they match the option name.