### PR TITLE
Remove commands to match tutorial and prevent conflict

### DIFF
--- a/pdf_viewer/keys.config
+++ b/pdf_viewer/keys.config
@@ -70,13 +70,12 @@ prev_chapter        g<S-c>
 # Goto previous viewing state and delete the current (and future) state(s).
 # pop_state           w
 
-# If we are not at the end of viewing history, goto the next history point
-next_state          <l>
 # Goto the previous history point
-prev_state          <h>
 prev_state          <backspace>
-next_state          <C-<right>>
 prev_state          <C-<left>>
+
+# If we are not at the end of viewing history, goto the next history point
+next_state          <C-<right>>
 
 # Open table of contents.
 goto_toc            t


### PR DESCRIPTION
Currently, opening any file warns about two conflicts between keys in the default key config.

`h` for prev_history and `l` for next_history are both undocumented in the tutorial, and have suitable alternatives already. I considered switching them to `<S-h>` and `<S-l>`, but i don't think these are as intuitive as the current keys, and I'm not sure if you're ok with that.