### PR TITLE
Use constant alpha blending factors

### DIFF
--- a/pdf_viewer/pdf_view_opengl_widget.cpp
+++ b/pdf_viewer/pdf_view_opengl_widget.cpp
@@ -265,7 +265,7 @@ void PdfViewOpenGLWidget::render_line_window(GLuint program, float gl_vertical_p
 	glEnableVertexAttribArray(0);
 	glEnableVertexAttribArray(1);
 	glEnable(GL_BLEND);
-	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+	glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE);
 	//glBufferData(GL_ARRAY_BUFFER, sizeof(line_data), line_data, GL_DYNAMIC_DRAW);
 	//glDrawArrays(GL_LINES, 0, 2);
 
@@ -333,7 +333,7 @@ void PdfViewOpenGLWidget::render_highlight_window(GLuint program, fz_rect window
 
 
 	glEnable(GL_BLEND);
-	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+	glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE);
 	glDisable(GL_CULL_FACE);
 
 	glUseProgram(program);


### PR DESCRIPTION
Fix #65. I don't see any difference between the original rendering in fullscreen mode (sway) and this in windowed mode.