### PR TITLE
Highlight on middle clicks when text is selected and no preview is open

### DIFF
--- a/pdf_viewer/config.cpp
+++ b/pdf_viewer/config.cpp
@@ -90,6 +90,7 @@ extern bool START_WITH_HELPER_WINDOW;
 extern std::map<std::wstring, std::wstring> ADDITIONAL_COMMANDS;
 extern bool PRERENDER_NEXT_PAGE;
 extern bool EMACS_MODE;
+extern bool HIGHLIGHT_MIDDLE_CLICK;
 
 template<typename T>
 void* generic_deserializer(std::wstringstream& stream, void* res_) {
@@ -321,6 +322,7 @@ ConfigManager::ConfigManager(const Path& default_path, const Path& auto_path ,co
 	configs.push_back({ L"start_with_helper_window", &START_WITH_HELPER_WINDOW, bool_serializer, bool_deserializer, bool_validator });
 	configs.push_back({ L"prerender_next_page_presentation", &PRERENDER_NEXT_PAGE, bool_serializer, bool_deserializer, bool_validator });
 	configs.push_back({ L"emacs_mode_menus", &EMACS_MODE, bool_serializer, bool_deserializer, bool_validator });
+	configs.push_back({ L"highlight_middle_click", &HIGHLIGHT_MIDDLE_CLICK, bool_serializer, bool_deserializer, bool_validator });
 
 	std::wstring highlight_config_string = L"highlight_color_a";
 	std::wstring search_url_config_string = L"search_url_a";

--- a/pdf_viewer/main.cpp
+++ b/pdf_viewer/main.cpp
@@ -192,6 +192,7 @@ bool START_WITH_HELPER_WINDOW = false;
 std::map<std::wstring, std::wstring> ADDITIONAL_COMMANDS;
 bool PRERENDER_NEXT_PAGE = false;
 bool EMACS_MODE = false;
+bool HIGHLIGHT_MIDDLE_CLICK = false;
 
 float PAGE_SEPARATOR_WIDTH = 0.0f;
 float PAGE_SEPARATOR_COLOR[3] = {0.9f, 0.9f, 0.9f};

--- a/pdf_viewer/main_widget.cpp
+++ b/pdf_viewer/main_widget.cpp
@@ -1479,7 +1479,13 @@ void MainWidget::mouseReleaseEvent(QMouseEvent* mevent) {
     }
 
     if (mevent->button() == Qt::MouseButton::MiddleButton) {
-        smart_jump_under_pos({ mevent->pos().x(), mevent->pos().y() });
+        if (opengl_widget->selected_character_rects.size() > 0 &&
+            !(opengl_widget && opengl_widget->get_overview_page())) {
+          handle_command(command_manager.get_command_with_name("add_highlight_with_current_type"), 1);
+        }
+        else {
+          smart_jump_under_pos({ mevent->pos().x(), mevent->pos().y() });
+        }
     }
 
 }

--- a/pdf_viewer/main_widget.cpp
+++ b/pdf_viewer/main_widget.cpp
@@ -102,6 +102,7 @@ extern std::wstring ALT_RIGHT_CLICK_COMMAND;
 extern Path local_database_file_path;
 extern Path global_database_file_path;
 extern std::map<std::wstring, std::wstring> ADDITIONAL_COMMANDS;
+extern bool HIGHLIGHT_MIDDLE_CLICK;
 
 bool MainWidget::main_document_view_has_document()
 {
@@ -1479,8 +1480,9 @@ void MainWidget::mouseReleaseEvent(QMouseEvent* mevent) {
     }
 
     if (mevent->button() == Qt::MouseButton::MiddleButton) {
-        if (opengl_widget->selected_character_rects.size() > 0 &&
-            !(opengl_widget && opengl_widget->get_overview_page())) {
+        if (HIGHLIGHT_MIDDLE_CLICK
+            && opengl_widget->selected_character_rects.size() > 0
+            && !(opengl_widget && opengl_widget->get_overview_page())) {
           handle_command(command_manager.get_command_with_name("add_highlight_with_current_type"), 1);
         }
         else {

--- a/pdf_viewer/prefs.config
+++ b/pdf_viewer/prefs.config
@@ -209,6 +209,9 @@ prerender_next_page_presentation 1
 # control_right_click_command some_command
 # alt_right_click_command some_command
 
+# Highlight on middle clicks when text is selected and no preview is open
+#highlight_middle_click 1
+
 #Amethyst
 highlight_color_a	0.94 0.64 1.00
 #Blue

--- a/resources/sioyek.1
+++ b/resources/sioyek.1
@@ -1307,6 +1307,13 @@ always warn the user when keys are overridden.
 If set to 0, then single clicks select words and double clicks allow selection
 of arbitrary ranges of characters. If set to 1, then double clicks select words
 and single clicks allow selection of arbitrary ranges of characters.
+.HP
+.B highlight_middle_click
+.I boolean
+
+If set to 1, then middle clicks add a highlight with select_highlight_type when
+a selection is active and no preview is open. If set to 0, a smart jump is
+always attempted.
 .SH BUGS
 If you find a bug in sioyek please report it at
 https://github.com/ahrm/sioyek/issues


### PR DESCRIPTION
I use this modification to keep the majority of my reading and annotation workflow keyboard-less. Do you have any thoughts on this?