### PR TITLE
fix!: Spelling

### DIFF
--- a/pdf_viewer/input.cpp
+++ b/pdf_viewer/input.cpp
@@ -15,6 +15,7 @@ extern std::map<std::wstring, std::wstring> ADDITIONAL_COMMANDS;
 
 CommandManager::CommandManager() {
 	commands.push_back({ "goto_beginning",				false,	false,	false,	true,	true,	{}});
+	commands.push_back({ "goto_begining",				false,	false,	false,	true,	true,	{}});
 	commands.push_back({ "goto_end",					false,	false,	false,	true,	true,	{}});
 	commands.push_back({ "goto_definition",				false,	false,	false,	true,	true,	{}});
 	commands.push_back({ "overview_definition",			false,	false,	false,	false,	true,	{}});

--- a/pdf_viewer/input.cpp
+++ b/pdf_viewer/input.cpp
@@ -14,7 +14,7 @@ extern bool USE_LEGACY_KEYBINDS;
 extern std::map<std::wstring, std::wstring> ADDITIONAL_COMMANDS;
 
 CommandManager::CommandManager() {
-	commands.push_back({ "goto_begining",				false,	false,	false,	true,	true,	{}});
+	commands.push_back({ "goto_beginning",				false,	false,	false,	true,	true,	{}});
 	commands.push_back({ "goto_end",					false,	false,	false,	true,	true,	{}});
 	commands.push_back({ "goto_definition",				false,	false,	false,	true,	true,	{}});
 	commands.push_back({ "overview_definition",			false,	false,	false,	false,	true,	{}});

--- a/pdf_viewer/keys.config
+++ b/pdf_viewer/keys.config
@@ -21,10 +21,10 @@
 
 # ---------- NAVIGATION AND ZOOM ----------
 
-# Goto the begining of document. If prefixed with a number, it will go to that page.
+# Goto the beginning of document. If prefixed with a number, it will go to that page.
 # for example 150gg goes to page 150.
-goto_begining       gg
-goto_begining		<C-<home>>
+goto_beginning       gg
+goto_beginning		<C-<home>>
 
 # Goto the end of the document
 goto_end            <end>
@@ -43,7 +43,7 @@ goto_page_with_page_number		<home>
 goto_left_smart     <S-^>
 goto_right_smart     <S-$>
 
-# Goto the top-right side of page. Usefull for two column documents
+# Goto the top-right side of page. Useful for two column documents
 goto_top_of_page;goto_right_smart zz
 
 # Movement (can be prefixed with a number)
@@ -53,7 +53,7 @@ move_left           <right>
 move_right          <left>
 
 # Goto forward for one page width. (can be prefixed with a number)
-# (note that going forward for one page width is not usually what you want becaue if 
+# (note that going forward for one page width is not usually what you want becaue if
 # the page is larger than the screen you will miss some content. What you usually want is screen_down)
 next_page           <C-<pagedown>>
 previous_page       <C-<pageup>>
@@ -123,7 +123,7 @@ open_document_embedded_from_current_path       <C-S-o>
 # Open a searchable list of previously opened documents.
 open_prev_doc       <S-o>
 
-## Opens the last document opened is sioyek. It is usefull when you want to quickly toggle between two documents
+## Opens the last document opened is sioyek. It is useful when you want to quickly toggle between two documents
 #open_last_document <unbound>
 
 ## Keyboard shortcut to enter visual mark mode (instead of right clicking)
@@ -136,12 +136,12 @@ move_visual_mark_down	j
 move_visual_mark_up		<up>
 move_visual_mark_down	<down>
 
-## lock horizontal scroll, usefull when using laptop touchpads
+## lock horizontal scroll, useful when using laptop touchpads
 # toggle_horizontal_scroll_lock <unbound>
 
 # ---------- SEARCH ----------
 
-# Search the document. 
+# Search the document.
 # example: /something                   (searches the document for 'something')
 # you can also specify a page range to search:
 # example: /<110,135>something          (searches pages 110 to 135 (inclusive) for 'something')
@@ -154,7 +154,7 @@ chapter_search      c<C-f>
 chapter_search      c/
 
 # Goto the next search item. Can be prefixed with a number which is the same as performing the command n times
-# for example if we are on the 10th search result and we input 15n, we go to the 25th search result. 
+# for example if we are on the 10th search result and we input 15n, we go to the 25th search result.
 next_item           n
 # Goto the previous search result. Can be prefixed with a number with similar rules as next_item.
 previous_item       <S-n>
@@ -247,7 +247,7 @@ toggle_highlight    <f1>
 # open command line
 command             <S-:>
 
-# Seach the selected text using one of the search engines defined using search_url_* settings in prefs.config (* can be any letter between 'a' and 'z')
+# Search the selected text using one of the search engines defined using search_url_* settings in prefs.config (* can be any letter between 'a' and 'z')
 # see https://sioyek-documentation.readthedocs.io/en/latest/usage.html#external-search
 external_search		s
 

--- a/pdf_viewer/main_widget.cpp
+++ b/pdf_viewer/main_widget.cpp
@@ -572,7 +572,7 @@ void MainWidget::handle_escape() {
         main_document_view->handle_escape();
         opengl_widget->handle_escape();
     }
-    
+
     if (opengl_widget) {
 		bool done_anything = false;
         if (opengl_widget->get_overview_page()) {
@@ -1740,7 +1740,7 @@ void MainWidget::handle_command(const Command* command, int num_repeats) {
         //user-defined commands start with underscore
         handle_additional_command(utf8_decode(command->name));
     }
-    if (command->name == "goto_begining") {
+    if (command->name == "goto_beginning") {
         if (num_repeats) {
             main_document_view->goto_page(num_repeats - 1 + main_document_view->get_page_offset());
         }
@@ -1791,7 +1791,7 @@ void MainWidget::handle_command(const Command* command, int num_repeats) {
 			}
         }
         else {
-			
+
 			if (command->name == "move_down") {
 				move_document(0.0f, 72.0f * rp * VERTICAL_MOVE_AMOUNT);
 			}
@@ -3361,7 +3361,7 @@ void MainWidget::dropEvent(QDropEvent* event)
     if (event->mimeData()->hasUrls()) {
         auto urls = event->mimeData()->urls();
         std::wstring path = urls.at(0).toString().toStdWString();
-        // ignore file:/// at the begining of the URL
+        // ignore file:/// at the beginning of the URL
 #ifdef Q_OS_WIN
         path = path.substr(8, path.size() - 8);
 #else
@@ -3460,7 +3460,7 @@ void MainWidget::on_new_paper_added(const std::wstring& file_path) {
         if (helper_document_view) {
             float helper_view_width = helper_document_view->get_view_width();
             float helper_view_height = helper_document_view->get_view_height();
-            float zoom_level = helper_view_width / first_page_width; 
+            float zoom_level = helper_view_width / first_page_width;
             dst_view_state.book_state.zoom_level = zoom_level;
 			dst_view_state.book_state.offset_y = -std::abs(-helper_view_height / zoom_level / 2 + first_page_height / 2);
         }
@@ -3507,7 +3507,7 @@ std::wstring MainWidget::get_serialized_configuration_string() {
     return overview_config_string + get_window_configuration_string();
 }
 std::wstring MainWidget::get_window_configuration_string() {
-	
+
 	QString config_string_multi = "main_window_size    %1 %2\nmain_window_move     %3 %4\nhelper_window_size    %5 %6\nhelper_window_move     %7 %8";
 	QString config_string_single = "single_main_window_size    %1 %2\nsingle_main_window_move     %3 %4";
 
@@ -3631,7 +3631,7 @@ void MainWidget::scroll_overview_up() {
 }
 
 int MainWidget::get_current_page_number() const {
-    // 
+    //
     if (opengl_widget->get_should_draw_vertical_line()) {
         return main_document_view->get_vertical_line_page();
     }
@@ -3856,7 +3856,7 @@ void MainWidget::add_portal(std::wstring source_path, Link new_link) {
 
 void MainWidget::handle_keyboard_select(const std::wstring& text) {
 	if (std::isdigit(text[0])) {
-        // we can select text 
+        // we can select text
 		QStringList parts = QString::fromStdWString(text).split(' ');
         if (parts.size() == 2) {
             QString begin_text = parts.at(0);

--- a/pdf_viewer/main_widget.cpp
+++ b/pdf_viewer/main_widget.cpp
@@ -1741,6 +1741,16 @@ void MainWidget::handle_command(const Command* command, int num_repeats) {
         handle_additional_command(utf8_decode(command->name));
     }
     if (command->name == "goto_beginning") {
+
+        if (num_repeats) {
+            main_document_view->goto_page(num_repeats - 1 + main_document_view->get_page_offset());
+        }
+        else {
+            main_document_view->set_offset_y(0.0f);
+        }
+    }
+    if (command->name == "goto_begining") {
+
         if (num_repeats) {
             main_document_view->goto_page(num_repeats - 1 + main_document_view->get_page_offset());
         }

--- a/pdf_viewer/utils.cpp
+++ b/pdf_viewer/utils.cpp
@@ -481,7 +481,7 @@ void get_flat_words_from_flat_chars(const std::vector<fz_stext_char*>& flat_char
 void get_word_rect_list_from_flat_chars(const std::vector<fz_stext_char*>& flat_chars,
 	std::vector<std::wstring>& words,
 	std::vector<std::vector<fz_rect>>& flat_word_rects) {
-	
+
 	if (flat_chars.size() == 0) return;
 
 	std::vector<fz_stext_char*> pending_word;
@@ -736,7 +736,7 @@ std::vector<std::wstring> split_whitespace(std::wstring const& input) {
 }
 
 void split_key_string(std::string haystack, const std::string& needle, std::vector<std::string> &res) {
-	//todo: we can significantly reduce string allocations in this function if it turns out to be a 
+	//todo: we can significantly reduce string allocations in this function if it turns out to be a
 	//performance bottleneck.
 
 	if (haystack == needle){
@@ -799,7 +799,7 @@ void run_command(std::wstring command, QStringList parameters, bool wait){
 #else
 	QProcess* process = new QProcess;
 	QString qcommand = QString::fromStdWString(command);
-	QStringList qparameters; 
+	QStringList qparameters;
 
 	for (int i = 0; i < parameters.size(); i++) {
 		qparameters.append(parameters[i]);
@@ -1013,7 +1013,7 @@ void index_generic(const std::vector<fz_stext_char*>& flat_chars, int page_numbe
 
 	int offset = 0;
 	while (std::regex_search(page_string, match, index_dst_regex)) {
-		
+
 		IndexedData new_data;
 		new_data.page = page_number;
 		std::wstring match_string = match.str();
@@ -1096,7 +1096,7 @@ void index_references(fz_stext_page* page, int page_number, std::map<std::wstrin
 				//	current_text.clear();
 				//}
 
-				// refernces are usually at the begining of the line, we consider the possibility
+				// references are usually at the beginning of the line, we consider the possibility
 				// of up to 3 extra characters before the reference (e.g. numbers, extra spaces, etc.)
 				if ((ch->c == start_char) && (chars_in_line < 4)) {
 					temp_indices.clear();
@@ -1623,13 +1623,13 @@ void check_for_updates(QWidget* parent, std::string current_version) {
 
 	QString url = "https://github.com/ahrm/sioyek/releases/latest";
 	QNetworkAccessManager* manager = new QNetworkAccessManager;
-	
+
 	QObject::connect(manager, &QNetworkAccessManager::finished, [=](QNetworkReply *reply) {
 		std::string response_text = reply->readAll().toStdString();
 		int first_index = response_text.find("\"");
 		int last_index = response_text.rfind("\"");
 		std::string url_string = response_text.substr(first_index + 1, last_index - first_index - 1);
-		
+
 		std::vector<std::wstring> parts;
 		split_path(utf8_decode(url_string), parts);
 		if (parts.size() > 0) {
@@ -1727,7 +1727,7 @@ QString get_color_hexadecimal(float color) {
 	int high = val / 16;
 	int low = val % 16;
 	return QString("%1%2").arg(hex_map[high], hex_map[low]);
-	
+
 }
 
 QString get_color_qml_string(float r, float g, float b) {
@@ -1787,7 +1787,7 @@ std::wstring truncate_string(const std::wstring& inp, int size) {
         else {
 		return inp.substr(0, size - 3) + L"...";
 	}
- 
+
 }
 
 std::wstring get_page_formatted_string(int page) {


### PR DESCRIPTION
Fixed some spelling in the configuration file as well as `goto_begining`
-> `goto_beginning` command.

This is a breaking change as it will force users to change their
configuration. Therefore it should be marked as such and probably be
only added at the next release.
