### PR TITLE
Correcting default keys for next_state to ones specified in documentation

### DIFF
--- a/pdf_viewer/keys.config
+++ b/pdf_viewer/keys.config
@@ -85,6 +85,7 @@ prev_state          <C-<left>>
 #goto_window <unbound>
 
 # If we are not at the end of viewing history, goto the next history point
+next_state          <S-<backspace>>
 next_state          <C-<right>>
 
 # Open table of contents.


### PR DESCRIPTION
In the documentation, it says that History Navigation can be done through backspace and Shift - backspace:

![image](https://user-images.githubusercontent.com/34071465/188018706-6852074b-2b66-41d7-b6d2-2c0d95d7e4d4.png)

While prev_state is indeed set to backspace by default, this is not true of next_state, which is likely unintended because prev_state did have the keybinding.