### PR TITLE
Treat multi-line matches as single matches

### DIFF
--- a/pdf_viewer/book.h
+++ b/pdf_viewer/book.h
@@ -95,7 +95,7 @@ struct Link {
 bool operator==(DocumentViewState& lhs, const DocumentViewState& rhs);
 
 struct SearchResult {
-	fz_rect rect;
+	std::vector<fz_rect> rects;
 	int page;
 };
 

--- a/pdf_viewer/document.cpp
+++ b/pdf_viewer/document.cpp
@@ -2364,9 +2364,7 @@ std::vector<SearchResult> Document::search_text(std::wstring query, int begin_pa
 		}
 
 		merge_selected_character_rects(match_rects, compressed_match_rects);
-		SearchResult res;
-		res.page = match_page;
-		res.rect = compressed_match_rects[0];
+		SearchResult res { compressed_match_rects, match_page };
 
 		if (!((match_page < min_page) || (match_page > max_page))) {
 			if (is_before) {
@@ -2428,9 +2426,7 @@ std::vector<SearchResult> Document::search_regex(std::wstring query, int begin_p
 			}
 
 			merge_selected_character_rects(match_rects, compressed_match_rects);
-			SearchResult res;
-			res.page = match_page;
-			res.rect = compressed_match_rects[0];
+			SearchResult res { compressed_match_rects, match_page };
 
 			if (!((match_page < min_page) || (match_page > max_page))) {
 				if (is_before) {

--- a/pdf_viewer/pdf_view_opengl_widget.cpp
+++ b/pdf_viewer/pdf_view_opengl_widget.cpp
@@ -453,10 +453,10 @@ void PdfViewOpenGLWidget::goto_search_result(int offset) {
 	int target_index = mod(current_search_result_index + offset, search_results.size());
 	current_search_result_index = target_index;
 
-	auto [rect, target_page] = search_results[target_index];
+	auto [rects, target_page] = search_results[target_index];
 	search_results_mutex.unlock();
 
-	float new_offset_y = rect.y0 + document_view->get_document()->get_accum_page_height(target_page);
+	float new_offset_y = rects.front().y0 + document_view->get_document()->get_accum_page_height(target_page);
 
 	document_view->set_offset_y(new_offset_y);
 }
@@ -755,7 +755,9 @@ void PdfViewOpenGLWidget::render(QPainter* painter) {
 		glUseProgram(shared_gl_objects.highlight_program);
 		glUniform3fv(shared_gl_objects.highlight_color_uniform_location, 1, config_manager->get_config<float>(L"search_highlight_color"));
 		//glUniform3fv(g_shared_resources.highlight_color_uniform_location, 1, highlight_color_temp);
-		render_highlight_document(shared_gl_objects.highlight_program, current_search_result.page, current_search_result.rect);
+		for (auto rect : current_search_result.rects) {
+			render_highlight_document(shared_gl_objects.highlight_program, current_search_result.page, rect);
+		}
 	}
 	search_results_mutex.unlock();
 


### PR DESCRIPTION
mupdf 1.20 indicates whether hit boxes belong to the same search hit as the previous box. This patch merges search results spanning multiple hit-boxes and displays them correctly.