### PR TITLE
Build instructions for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,25 @@ You can customize all key bindings and some UI elements by editing `keys_user.co
 ## Build Instructions
 
 ### Linux
+
+#### Fedora
+
+Run the following commands to install dependencies, clone the repository and compile sioyek on Fedora (tested on Fedora Workstation 36).
+
+Notice that we change `qmake` into `qmake-qt5` in `build_linux.sh` since in Fedora `qmake` points to qmake for Qt 3.x, while we need qmake for Qt 5.x:
+
+```
+sudo dnf install qt5-qtbase-devel qt5-qtbase-static qt5-qt3d-devel harfbuzz-devel
+git clone --recursive https://github.com/ahrm/sioyek
+cd sioyek
+sed -i "s/qmake/qmake-qt5/g" build_linux.sh
+./build_linux.sh
+``` 
+
+#### Generic distribution
 1. Install Qt 5 and make sure `qmake` is in `PATH`.
+
+    Run `qmake --version` to make sure the `qmake` in path is using Qt 5.x.
 2. Install `libharfbuzz`:
 ```
 sudo apt install libharfbuzz-dev


### PR DESCRIPTION
Fedora has qmake pointing to Qt 3.x.

Also specify to check for qmake in README.