### PR TITLE
Move executable

### DIFF
--- a/build_linux.sh
+++ b/build_linux.sh
@@ -22,7 +22,7 @@ make
 # Copy files in build/ subdirectory
 rm -r build 2> /dev/null
 mkdir build
-cp sioyek build/sioyek
+mv sioyek build/sioyek
 cp pdf_viewer/prefs.config build/prefs.config
 cp pdf_viewer/prefs_user.config build/prefs_user.config
 cp pdf_viewer/keys.config build/keys.config


### PR DESCRIPTION
Move the executable into the build directory instead of copying it since it won't work where it is and so it makes no sense to keep it there