### PR TITLE
Fix spelling errors in manual page

### DIFF
--- a/resources/sioyek.1
+++ b/resources/sioyek.1
@@ -928,7 +928,7 @@ move_left/right commands.
 .B flat_toc
 .I boolean
 
-If 0, Table of Contents is shown in a hierarchial tree, otherwise it
+If 0, Table of Contents is shown in a hierarchical tree, otherwise it
 is a flat list (can improve performance for extremely large table of
 contents).
 .HP
@@ -1116,7 +1116,7 @@ Default size (in width and height) of the helper window when it is
 opened.
 
 If not set, use the full size of the second screen if there are
-mulitple monitors, otherwise use half of the width of the first screen
+multiple monitors, otherwise use half of the width of the first screen
 and the whole height.
 .HP
 .B helper_window_move


### PR DESCRIPTION
In the course of packaging sioyek for Debian (see https://salsa.debian.org/viccie30/sioyek) lintian, Debian's packaging linter, came across these spelling errors in the man page for sioyek.