### PR TITLE
Define fallback for GL_CLAMP

### DIFF
--- a/pdf_viewer/pdf_renderer.cpp
+++ b/pdf_viewer/pdf_renderer.cpp
@@ -143,8 +143,13 @@ GLuint PdfRenderer::find_rendered_page(std::wstring path, int page, float zoom_l
 						glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 					}
 
+#ifdef GL_CLAMP
 					glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP);
 					glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP);
+#else
+					glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+					glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+#endif
 
 
 					// OpenGL usually expects powers of two textures and since our pixmaps dimensions are


### PR DESCRIPTION
This texture wrap OpenGL parameter is not available on all architectures through QtOpenGL.

This lead to a build failure on armel for the Debian package that got accepted today (see https://buildd.debian.org/status/package.php?p=sioyek). According to [SO](https://stackoverflow.com/questions/56823126/how-is-gl-clamp-in-opengl-different-from-gl-clamp-to-edge) GL_CLAMP was removed in newer versions of OpenGL.
