### PR TITLE
Add Debian package to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Alpine | [sioyek](https://pkgs.alpinelinux.org/packages?name=sioyek) | [@jirutka
 Arch | [AUR sioyek](https://aur.archlinux.org/packages/sioyek) | [@goggle](https://github.com/goggle)
 Arch | [AUR Sioyek-git](https://aur.archlinux.org/packages/sioyek-git/) | [@randomn4me](https://github.com/randomn4me)
 Arch | [AUR sioyek-appimage](https://aur.archlinux.org/packages/sioyek-appimage/) | [@DhruvaSambrani](https://github.com/DhruvaSambrani)
+Debian | [sioyek](https://packages.debian.org/unstable/sioyek) | [@viccie30](https://github.com/viccie30)
 NixOS | [sioyek](https://search.nixos.org/packages?channel=unstable&show=sioyek&from=0&size=50&sort=relevance&type=packages&query=sioyek) | [@podocarp](https://github.com/podocarp)
 openSUSE | [Publishing](https://build.opensuse.org/package/show/Publishing/sioyek) | [@uncomfyhalomacro](https://github.com/uncomfyhalomacro)
 openSUSE | [Factory](https://build.opensuse.org/package/show/openSUSE:Factory/sioyek) | [@uncomfyhalomacro](https://github.com/uncomfyhalomacro)


### PR DESCRIPTION
Sioyek has recently been accepted into the Debian archives. I will maintain the Debian package in the future. Once the package makes its way into Ubuntu, I can add a line for that as well.

I've tried to keep the distros sorted alphabetically.