### PR TITLE
Fix: stop build on error

### DIFF
--- a/build_and_release.sh
+++ b/build_and_release.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 if [ -z ${MAKE_PARALLEL+x} ]; then export MAKE_PARALLEL=1; else echo "MAKE_PARALLEL defined"; fi
 echo "MAKE_PARALLEL set to $MAKE_PARALLEL"

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 # Compile mupdf
 cd mupdf

--- a/build_mac.sh
+++ b/build_mac.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 # prerequisite: brew install qt@5 freeglut mesa harfbuzz
 
 #sys_glut_clfags=`pkg-config --cflags glut gl`


### PR DESCRIPTION
If an error occurs during any of the build process (e.g., if one doesn't have `unzip` installed, which is not listed as a requirement), the build continues all the same, even though it will ultimately fail. Using `set -e` causes the build script to halt when any command returns a non-zero retcode, making debugging failing builds that much easier. :) 
