### PR TITLE
Next / previous page commands: remove 1-offset by repeat command

### DIFF
--- a/pdf_viewer/input.cpp
+++ b/pdf_viewer/input.cpp
@@ -482,7 +482,7 @@ class FitToPageHeightSmartCommand : public Command {
 
 class NextPageCommand : public Command {
 	void perform(MainWidget* widget) {
-		widget->main_document_view->move_pages(1 + num_repeats);
+		widget->main_document_view->move_pages(std::max(1, num_repeats));
 	}
 	std::string get_name() {
 		return "next_page";
@@ -491,7 +491,7 @@ class NextPageCommand : public Command {
 
 class PreviousPageCommand : public Command {
 	void perform(MainWidget* widget) {
-		widget->main_document_view->move_pages(-1 - num_repeats);
+		widget->main_document_view->move_pages(std::min(-1, -num_repeats));
 	}
 
 	std::string get_name() {


### PR DESCRIPTION
I find this approach more intuitive. I usually use the repeat function in combination with next / previous page commands to adjust for offsets in physical page numbers and physical page numbers. This is also how e.g. the next item command works.