### PR TITLE
Workaround for ligatures

### DIFF
--- a/pdf_viewer/utils.cpp
+++ b/pdf_viewer/utils.cpp
@@ -349,12 +349,12 @@ std::vector<fz_stext_char*> reorder_stext_line(fz_stext_line* line) {
 
 	if (rtl) {
 		std::sort(reordered_chars.begin(), reordered_chars.end(), [](fz_stext_char* lhs, fz_stext_char* rhs) {
-			return lhs->quad.ll.x > rhs->quad.ll.x;
+			return (lhs->quad.lr.x >= rhs->quad.lr.x) && (lhs->quad.ll.x > rhs->quad.ll.x);
 			});
 	}
 	else {
 		std::sort(reordered_chars.begin(), reordered_chars.end(), [](fz_stext_char* lhs, fz_stext_char* rhs) {
-			return lhs->quad.ll.x < rhs->quad.ll.x;
+			return (lhs->quad.lr.x <= rhs->quad.lr.x) && (lhs->quad.ll.x < rhs->quad.ll.x);
 			});
 	}
 	return reordered_chars;


### PR DESCRIPTION
Before this ligatures resulted in swapped letters in structured text representations. Fixes #724.

Reading through the issue I just submitted I came up with this workaround. I will test if this works reliably during the next few days. I have not tested this with any RTL documents. Unless you know an example of an RTL document that features ligatures (which in practice only exist in the Latin alphabet, I guess) it might be safer to remove my modification.