### PR TITLE
Introduce named instances

### DIFF
--- a/pdf_viewer/main.cpp
+++ b/pdf_viewer/main.cpp
@@ -733,7 +733,8 @@ int main(int argc, char* args[]) {
 		use_single_instance = false;
 	}
 
-	RunGuard guard("sioyek");
+	char* instance_name = get_argv_value(argc, args, "--instance-name");
+	RunGuard guard(instance_name ? instance_name : "sioyek");
 
 	if (!guard.isPrimary()) {
 		QStringList sent_args = convert_arguments(app.arguments());

--- a/pdf_viewer/utils.cpp
+++ b/pdf_viewer/utils.cpp
@@ -1554,6 +1554,10 @@ QCommandLineParser* get_command_line_parser() {
 	//new_instance_option.setDescription("When opening a new file, create a new instance of sioyek.");
 	//parser->addOption(new_instance_option);
 
+	QCommandLineOption instance_name_option("instance-name");
+	instance_name_option.setDescription("Select a specific sioyek instance by name.");
+	parser->addOption(instance_name_option);
+
 	QCommandLineOption new_window_option("new-window");
 	new_window_option.setDescription("Open the file in a new window but within the same sioyek instance (reuses the previous window if a sioyek window with the same file already exists).");
 	parser->addOption(new_window_option);

--- a/resources/sioyek.1
+++ b/resources/sioyek.1
@@ -691,6 +691,10 @@ is set in a preference file (see below), then open a tutorial PDF.
 
 Displays version information
 .HP
+.B --instance-name
+
+Select a specific sioyek instance by name.
+.HP
 .B --new-window
 
 Open the file in a new window but within the same sioyek instance.


### PR DESCRIPTION
For me it makes sense to use two sioyek instances simultaneously: one for reading papers and another one to display papers I author using synctex. Additional tasks:

- [ ] Clean up command line argument handling, as `convert_arguments()` mistakes the argument any first option with the file to be opened.
- [ ] Sanitise `instance_name`