### PR TITLE
Info.plist: Add CFBundleName

### DIFF
--- a/resources/Info.plist
+++ b/resources/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleName</key>
+	<string>sioyek</string>
 	<key>CFBundleExecutable</key>
 	<string>@EXECUTABLE@</string>
 	<key>CFBundleIconFile</key>


### PR DESCRIPTION
Package managers such as Nix create wrapper scripts around binaries to for example inject library paths into any invocation of the program.

In case of Nix, this means that in the final distribution of the program the path that would
canonically hold the application binary (think `/bin/sioyek`) is instead taken by the wrapper script, which itself internally exec's the actual binary which is hidden away under a different name (`/bin/.sioyek-wrapped`).

When installing sioyek on MacOS via Nix, this yields the following problem:

<img width="176" alt="image" src="https://github.com/ahrm/sioyek/assets/40795431/6fc2e5c1-5d87-4885-9665-1c7dbaea65cb">

Without a `CFBundleName` field set in `Info.plist`, MacOS chooses the application name shown in the top left of the menu bar based on the name of its binary, which as shown may not actually be "sioyek".

While this is also a packaging issue, it would arguably be best practice to just include the `CFBundleName` in the upstream `Info.plist` anyways as I assume this is unwanted behavior.