### PR TITLE
Add support for mupdf 1.23

### DIFF
--- a/pdf_viewer/document_view.cpp
+++ b/pdf_viewer/document_view.cpp
@@ -1126,7 +1126,7 @@ std::vector<DocumentPos> DocumentView::find_line_definitions() {
 
 			std::optional<PdfLink> pdf_link = current_document->get_link_in_page_rect(get_center_page_number(), line_rects[line_index]);
 			if (pdf_link.has_value()) {
-				auto parsed_uri = parse_uri(mupdf_context, pdf_link.value().uri);
+				auto parsed_uri = parse_uri(mupdf_context, current_document->doc, pdf_link.value().uri);
 				result.push_back({ parsed_uri.page - 1, parsed_uri.x, parsed_uri.y });
 				return result;
 			}
@@ -1217,7 +1217,7 @@ void DocumentView::get_visible_links(std::vector<std::pair<int, fz_link*>>& visi
 	for (auto page : visible_pages) {
 		fz_link* link = get_document()->get_page_links(page);
 		while (link) {
-            ParsedUri parsed_uri = parse_uri(mupdf_context, link->uri);
+            ParsedUri parsed_uri = parse_uri(mupdf_context, get_document()->doc, link->uri);
             fz_rect window_rect = document_to_window_rect(page, link->rect);
             if ((window_rect.x0 >= -1) && (window_rect.x0 <= 1) && (window_rect.y0 >= -1) && (window_rect.y0 <= 1)) {
                 visible_page_links.push_back(std::make_pair(page, link));

--- a/pdf_viewer/main_widget.cpp
+++ b/pdf_viewer/main_widget.cpp
@@ -179,7 +179,7 @@ void MainWidget::set_overview_position(int page, float offset) {
 
 void MainWidget::set_overview_link(PdfLink link) {
 
-    auto [page, offset_x, offset_y] = parse_uri(mupdf_context, link.uri);
+    auto [page, offset_x, offset_y] = parse_uri(mupdf_context, doc()->doc, link.uri);
     if (page >= 1) {
         set_overview_position(page - 1, offset_y);
     }
@@ -2771,7 +2771,7 @@ void MainWidget::handle_link_click(const PdfLink& link) {
 		return;
 	}
 
-	auto [page, offset_x, offset_y] = parse_uri(mupdf_context, link.uri);
+	auto [page, offset_x, offset_y] = parse_uri(mupdf_context, doc()->doc, link.uri);
 
 	// convert one indexed page to zero indexed page
 	page--;
@@ -3920,7 +3920,7 @@ void MainWidget::handle_portal_to_link(const std::wstring& text) {
         PdfLink pdf_link;
         pdf_link.rect = link->rect;
         pdf_link.uri = link->uri;
-        ParsedUri parsed_uri = parse_uri(mupdf_context, pdf_link.uri);
+        ParsedUri parsed_uri = parse_uri(mupdf_context, doc()->doc, pdf_link.uri);
 
 		//AbsoluteDocumentPos abspos = doc()->document_to_absolute_pos(defpos[0], true);
         DocumentPos link_source_document_pos;
@@ -3959,7 +3959,7 @@ void MainWidget::handle_open_link(const std::wstring& text, bool copy) {
 				open_web_url(utf8_decode(selected_link->uri));
 			}
 			else {
-				auto [page, offset_x, offset_y] = parse_uri(mupdf_context, selected_link->uri);
+				auto [page, offset_x, offset_y] = parse_uri(mupdf_context, doc()->doc, selected_link->uri);
 				long_jump_to_destination(page - 1, offset_y);
 			}
 		}

--- a/pdf_viewer/utils.cpp
+++ b/pdf_viewer/utils.cpp
@@ -116,8 +116,9 @@ bool rects_intersect(fz_rect rect1, fz_rect rect2) {
 	return range_intersects(rect1.x0, rect1.x1, rect2.x0, rect2.x1) && range_intersects(rect1.y0, rect1.y1, rect2.y0, rect2.y1);
 }
 
-ParsedUri parse_uri(fz_context* mupdf_context, std::string uri) {
-	fz_link_dest dest = pdf_parse_link_uri(mupdf_context, uri.c_str());
+ParsedUri parse_uri(fz_context* mupdf_context, fz_document* fz_doc, std::string uri) {
+	pdf_document* doc = pdf_document_from_fz_document(mupdf_context, fz_doc);
+	fz_link_dest dest = pdf_resolve_link_dest(mupdf_context, doc, uri.c_str());
 	return { dest.loc.page + 1, dest.x, dest.y };
 }
 

--- a/pdf_viewer/utils.h
+++ b/pdf_viewer/utils.h
@@ -55,7 +55,7 @@ void get_flat_toc(const std::vector<TocNode*>& roots, std::vector<std::wstring>&
 int mod(int a, int b);
 bool range_intersects(float range1_start, float range1_end, float range2_start, float range2_end);
 bool rects_intersect(fz_rect rect1, fz_rect rect2);
-ParsedUri parse_uri(fz_context* mupdf_context, std::string uri);
+ParsedUri parse_uri(fz_context* mupdf_context, fz_document* fz_doc, std::string uri);
 char get_symbol(int key, bool is_shift_pressed, const std::vector<char>&special_symbols);
 
 template<typename T>


### PR DESCRIPTION
I've adapted @ptrcnull's patch for Alpine Linux a while ago. This also compiles against mupdf 1.20, but I haven't tested it on mupdf 1.20 as sioyek crashes on Arch Linux when not linking against the system's mupdf/harfbuzz library.