### PR TITLE
Fix: Setting `should_launch_new_window` should open new window even if file is already opened

### DIFF
--- a/pdf_viewer/main.cpp
+++ b/pdf_viewer/main.cpp
@@ -595,7 +595,7 @@ MainWidget* handle_args(const QStringList& arguments) {
 		if (parser->isSet("new-window")) {
 			should_create_new_window = true;
 		}
-		if (SHOULD_LAUNCH_NEW_WINDOW && (target_window == nullptr) && (!parser->isSet("reuse-window"))) {
+		if (SHOULD_LAUNCH_NEW_WINDOW && (!parser->isSet("reuse-window"))) {
 			should_create_new_window = true;
 		}
 		if (windows[0]->doc() == nullptr) {


### PR DESCRIPTION
Closes #830. 

**Summary of changes**

Removed `(target_window == nullptr)` from the if condition so new windows are launched properly when `should_launch_new_window` is set. Setting `should_launch_new_window` now has the same functionality as calling sioyek with the `--new-window` flag. 

This issue might be an intentional design choice rather than a bug, but I thought I'd submit this PR anyways. The `should_launch_new_window` property and the `--new-window` should logically provide the same functionality in my opinion.