### PR TITLE
feat: add refresh command

### DIFF
--- a/pdf_viewer/input.cpp
+++ b/pdf_viewer/input.cpp
@@ -1597,6 +1597,16 @@ class ReloadCommand : public Command {
 	}
 };
 
+
+class RefreshCommand : public Command {
+  void perform(MainWidget* widget) {
+    widget->refresh();
+  }
+  std::string get_name() {
+    return "refresh";
+  }
+};
+
 class ReloadConfigCommand : public Command {
 	void perform(MainWidget* widget) {
 		widget->on_config_file_changed(widget->config_manager);
@@ -2297,6 +2307,7 @@ CommandManager::CommandManager(ConfigManager* config_manager) {
 	new_commands["goto_bottom_of_page"] = []() {return std::make_unique< GotoBottomOfPageCommand>(); };
 	new_commands["new_window"] = []() {return std::make_unique< NewWindowCommand>(); };
 	new_commands["reload"] = []() {return std::make_unique< ReloadCommand>(); };
+	new_commands["refresh"] = []() {return std::make_unique< RefreshCommand>(); };
 	new_commands["reload_config"] = []() {return std::make_unique< ReloadConfigCommand>(); };
 	new_commands["synctex_under_cursor"] = []() {return std::make_unique< SynctexUnderCursorCommand>(); };
 	new_commands["set_status_string"] = []() {return std::make_unique< SetStatusStringCommand>(); };

--- a/pdf_viewer/main_widget.cpp
+++ b/pdf_viewer/main_widget.cpp
@@ -3011,6 +3011,14 @@ void MainWidget::reload() {
     }
 }
 
+void MainWidget::refresh() {
+    if (doc()) {
+      doc()->reload();
+      pdf_renderer->clear_cache();
+      invalidate_render();
+    }
+}
+
 
 void MainWidget::synctex_under_pos(WindowPos position) {
 	auto [page, doc_x, doc_y] = main_document_view->window_to_document_pos(position);

--- a/pdf_viewer/main_widget.h
+++ b/pdf_viewer/main_widget.h
@@ -204,6 +204,7 @@ public:
 	void return_to_last_visual_mark();
 	bool is_visual_mark_mode();
 	void reload();
+	void refresh();
 
 	QString get_font_face_name(); 
 

--- a/scripts/sioyek.py
+++ b/scripts/sioyek.py
@@ -571,6 +571,10 @@ class Sioyek:
         data = None
         self.run_command("reload", data, focus=focus)
 
+    def refresh(self, focus=False):
+        data = None
+        self.run_command("refresh", data, focus=focus)
+
     def synctex_under_cursor(self, focus=False):
         data = None
         self.run_command("synctex_under_cursor", data, focus=focus)


### PR DESCRIPTION
Closes #685. 

**Summary of changes**

Added a `refresh` command which reloads the document. This is different from the `reload` command, which restarts Sioyek, causing a momentary flicker (blank page). 

The refresh command is identical in functionality to the code that is executed when a file change is detected:

https://github.com/ahrm/sioyek/blob/ceae13b12df5653d3fe9e087167081e69a2ad48c/pdf_viewer/main_widget.cpp#L456-L471