### PR TITLE
Treating `backspace` as `delete` for compatibility on macOS

### DIFF
--- a/pdf_viewer/ui.h
+++ b/pdf_viewer/ui.h
@@ -182,7 +182,7 @@ public:
 #ifdef SIOYEK_QT6
 			if (event->type() == QEvent::KeyRelease) {
 				QKeyEvent* key_event = static_cast<QKeyEvent*>(event);
-				if (key_event->key() == Qt::Key_Delete) {
+				if (key_event->key() == Qt::Key_Delete  or event->key() == Qt::Key_Backspace) {
 					handle_delete();
 				}
 			}
@@ -294,7 +294,7 @@ public:
 
 #ifndef SIOYEK_QT6
 	void keyReleaseEvent(QKeyEvent* event) override {
-		if (event->key() == Qt::Key_Delete) {
+		if (event->key() == Qt::Key_Delete or event->key() == Qt::Key_Backspace) {
 			handle_delete();
 		}
 		QWidget::keyReleaseEvent(event);

--- a/pdf_viewer/ui.h
+++ b/pdf_viewer/ui.h
@@ -182,7 +182,7 @@ public:
 #ifdef SIOYEK_QT6
 			if (event->type() == QEvent::KeyRelease) {
 				QKeyEvent* key_event = static_cast<QKeyEvent*>(event);
-				if (shouldTriggerDelete(event)) {
+				if (should_trigger_delete(event)) {
 					handle_delete();
 				}
 			}
@@ -294,7 +294,7 @@ public:
 
 #ifndef SIOYEK_QT6
 	void keyReleaseEvent(QKeyEvent* event) override {
-		if (shouldTriggerDelete(event)) {
+		if (should_trigger_delete(event)) {
 			handle_delete();
 		}
 		QWidget::keyReleaseEvent(event);

--- a/pdf_viewer/ui.h
+++ b/pdf_viewer/ui.h
@@ -182,7 +182,7 @@ public:
 #ifdef SIOYEK_QT6
 			if (event->type() == QEvent::KeyRelease) {
 				QKeyEvent* key_event = static_cast<QKeyEvent*>(event);
-				if (key_event->key() == Qt::Key_Delete  or event->key() == Qt::Key_Backspace) {
+				if (shouldTriggerDelete(event)) {
 					handle_delete();
 				}
 			}
@@ -294,7 +294,7 @@ public:
 
 #ifndef SIOYEK_QT6
 	void keyReleaseEvent(QKeyEvent* event) override {
-		if (event->key() == Qt::Key_Delete or event->key() == Qt::Key_Backspace) {
+		if (shouldTriggerDelete(event)) {
 			handle_delete();
 		}
 		QWidget::keyReleaseEvent(event);

--- a/pdf_viewer/utils.cpp
+++ b/pdf_viewer/utils.cpp
@@ -2259,7 +2259,7 @@ void convert_color4(float* in_color, int* out_color) {
 	out_color[3] = (int)(in_color[3] * 255);
 }
 
-bool shouldTriggerDelete(QKeyEvent *key_event) {
+bool should_trigger_delete(QKeyEvent *key_event) {
     if (!key_event) {
         return false;
     }

--- a/pdf_viewer/utils.cpp
+++ b/pdf_viewer/utils.cpp
@@ -24,6 +24,8 @@
 #include <qnetworkrequest.h>
 #include <qnetworkreply.h>
 #include <qscreen.h>
+#include <QKeyEvent>
+#include <QtGlobal>
 
 #include <mupdf/pdf.h>
 
@@ -2255,4 +2257,25 @@ void convert_color4(float* in_color, int* out_color) {
 	out_color[1] = (int)(in_color[1] * 255);
 	out_color[2] = (int)(in_color[2] * 255);
 	out_color[3] = (int)(in_color[3] * 255);
+}
+
+bool shouldTriggerDelete(QKeyEvent *key_event) {
+    if (!key_event) {
+        return false;
+    }
+
+    // Check for the Delete key
+    if (key_event->key() == Qt::Key_Delete) {
+        return true;
+    }
+
+    // On macOS, treat the Backspace key as Delete as well
+#ifdef Q_OS_MAC
+    if (key_event->key() == Qt::Key_Backspace) {
+        return true;
+    }
+#endif
+
+    // For other platforms, Backspace does not trigger delete
+    return false;
 }

--- a/pdf_viewer/utils.h
+++ b/pdf_viewer/utils.h
@@ -213,4 +213,4 @@ void matmul(float m1[], float m2[], float result[]) {
 void convert_color4(float* in_color, int* out_color);
 std::string get_aplph_tag(int n, int max_n);
 
-bool shouldTriggerDelete(QKeyEvent *key_event);
+bool should_trigger_delete(QKeyEvent *key_event);

--- a/pdf_viewer/utils.h
+++ b/pdf_viewer/utils.h
@@ -12,6 +12,8 @@
 #include <memory>
 #include <qcommandlineparser.h>
 
+#include <QKeyEvent>
+
 #include <qstandarditemmodel.h>
 #include <qpoint.h>
 
@@ -210,3 +212,5 @@ void matmul(float m1[], float m2[], float result[]) {
 
 void convert_color4(float* in_color, int* out_color);
 std::string get_aplph_tag(int n, int max_n);
+
+bool shouldTriggerDelete(QKeyEvent *key_event);


### PR DESCRIPTION
This PR solves https://github.com/ahrm/sioyek/issues/904 .