### PR TITLE
workaround for bug #565

### DIFF
--- a/pdf_viewer/ui.h
+++ b/pdf_viewer/ui.h
@@ -631,6 +631,35 @@ public:
 		table_view->horizontalHeader()->hide();
 		table_view->verticalHeader()->hide();
 
+		adjustRowHeights(table_view);
+	}
+
+	void adjustRowHeights(QTableView* table_view) {
+		///
+		// Adjust row height based on the font size
+		QFontMetrics metrics(table_view->font());
+		// Unimportant Bug: The font we retrieve here does not seem to have the correct `height`. We are reliant on the padding below to make things work.
+		int rowHeight = metrics.height() + FONT_SIZE; // Add some padding
+		for (int row = 0; row < standard_item_model->rowCount(); ++row) {
+			table_view->setRowHeight(row, rowHeight);
+		}
+		///
+		// The following alternative sometimes work after entering some characters and deleting them. But it does not work at first.
+		// QStandardItemModel* model = qobject_cast<QStandardItemModel*>(table_view->model());
+		// if (!model) return;
+
+		// for (int row = 0; row < model->rowCount(); ++row) {
+		// 	int maxRowHeight = 10; // set the minimum height
+		// 	for (int col = 0; col < model->columnCount(); ++col) {
+		// 		QStandardItem* item = model->item(row, col);
+		// 		if (item) {
+		// 			QSize itemSizeHint = item->sizeHint();
+		// 			maxRowHeight = qMax(maxRowHeight, itemSizeHint.height());
+		// 		}
+		// 	}
+		// 	table_view->setRowHeight(row, maxRowHeight);
+		// }
+		///
 	}
 
 	virtual bool on_text_change(const QString& text) {

--- a/pdf_viewer/ui.h
+++ b/pdf_viewer/ui.h
@@ -556,6 +556,10 @@ private:
 				command_key += ck;
 			}
 
+#ifdef Q_OS_MAC
+			// Workaround for QT bug on macOS that puts the scrollbars on our text
+			command_key += "    ";
+#endif
 		}
 		QStandardItem* name_item = new QStandardItem(QString::fromStdString(command_name));
 		QStandardItem* key_item = new QStandardItem(QString::fromStdString(command_key));


### PR DESCRIPTION
This PR solves the two issues in [[BUG] Bigger font sizes make menu text go off screen · Issue #565 · ahrm/sioyek](https://github.com/ahrm/sioyek/issues/565).

1. The scrollbar hiding the shortcuts.
2. The height of the menu rows not adjusting to big font sizes:
<img width="1216" alt="image" src="https://github.com/ahrm/sioyek/assets/36224762/d1de69b7-517b-4b8f-8396-a196e682c090">

---
The final result looks like this:
<img width="1280" alt="image" src="https://github.com/ahrm/sioyek/assets/36224762/adf98423-fd82-4d88-8b56-36f6870965ce">
