### PR TITLE
InputHandler::handle_key: fixed bug in handling Backspace on macOS

### DIFF
--- a/pdf_viewer/input.cpp
+++ b/pdf_viewer/input.cpp
@@ -2703,7 +2703,7 @@ std::vector<std::unique_ptr<Command>> InputHandler::handle_key(QKeyEvent* key_ev
 
 	int key = 0;
 	if (!USE_LEGACY_KEYBINDS){
-		std::vector<QString> special_texts = {"\b", "\t", " ", "\r", "\n"};
+		std::vector<QString> special_texts = {"\b", "\u007F", "\t", " ", "\r", "\n"};
 		if (((key_event->key() >= 'A') && (key_event->key() <= 'Z')) || ((key_event->text().size() > 0) &&
 			(std::find(special_texts.begin(), special_texts.end(), key_event->text()) == special_texts.end()))) {
 			if (!control_pressed && !alt_pressed) {


### PR DESCRIPTION
This fixes a bug where `backspace` hotkeys did not work on macOS. 

This fix changes the code minimally, but I believe the current code needs to be changed to check directly using QT constants (e.g., `key == Qt::Key::Key_Backtab`). The current approach is fragile and possibly has more broken edge cases not yet discovered.