### PR TITLE
update page number in selected_rect

### DIFF
--- a/pdf_viewer/main_widget.cpp
+++ b/pdf_viewer/main_widget.cpp
@@ -3568,6 +3568,7 @@ void MainWidget::execute_command(std::wstring command, std::wstring text, bool w
             int selected_rect_page = -1;
             std::optional<DocumentRect> selected_rect_document = get_selected_rect_document();
             if (selected_rect_document) {
+                selected_rect_page = selected_rect_document->page;
                 QString format_string = "%1,%2,%3,%4,%5";
                 QString rect_string = format_string
                     .arg(QString::number(selected_rect_page))


### PR DESCRIPTION
Fixes a bug where the select_rect returns always -1 as page number