### PR TITLE
Add <C-d> and <C-u> as shortcuts for screen_up/screen_down

### DIFF
--- a/pdf_viewer/keys.config
+++ b/pdf_viewer/keys.config
@@ -59,7 +59,9 @@ previous_page <C-<pageup>>
 screen_down <space>
 screen_up <S-<space>>
 screen_down <pagedown>
+screen_down <C-d>
 screen_up <pageup>
+screen_up <C-u>
 
 # Goto the next/prev chapter
 next_chapter gc


### PR DESCRIPTION
Hi, and thanks for this awesome project.

I added <C-d> and <C-u> for screen_up/screen_down since they are standard vim bindings. 
I know I could add them to my own config, but since they are very useful in vim, and are standard, I think they should be among the default keybinds.
