### PR TITLE
Add option to hide the titlebar on MacOS.

### DIFF
--- a/pdf_viewer/config.cpp
+++ b/pdf_viewer/config.cpp
@@ -257,6 +257,7 @@ extern int RELOAD_INTERVAL_MILISECONDS;
 
 #ifdef Q_OS_MACOS
 extern float MACOS_TITLEBAR_COLOR[3];
+extern bool MACOS_HIDE_TITLEBAR;
 #endif
 
 #ifdef SIOYEK_ANDROID
@@ -2111,6 +2112,14 @@ ConfigManager::ConfigManager(const Path& default_path, const Path& auto_path, co
         vec3_serializer,
         color3_deserializer,
         color_3_validator
+        });
+    configs.push_back({
+        L"macos_hide_titlebar",
+        ConfigType::Bool,
+        &MACOS_HIDE_TITLEBAR,
+        bool_serializer,
+        bool_deserializer,
+        bool_validator
         });
 #endif
 

--- a/pdf_viewer/macos_specific.mm
+++ b/pdf_viewer/macos_specific.mm
@@ -1,3 +1,4 @@
+#include <AppKit/AppKit.h>
 #include <QWidget>
 #import <Cocoa/Cocoa.h>
 
@@ -7,4 +8,98 @@ extern "C" void changeTitlebarColor(WId winId, double red, double green, double 
     NSWindow* window = [view window];
     window.titlebarAppearsTransparent = YES;
     window.backgroundColor = [NSColor colorWithRed:red green:green blue:blue alpha: alpha];
+}
+
+@interface DraggableTitleView : NSView
+@end
+
+@implementation DraggableTitleView
+
+// Handle mouse click events
+- (void)mouseDown:(NSEvent *)event {
+  // double-click to zoom
+  if ([event clickCount] == 2) {
+    [self.window zoom:nil];
+  } else {
+    // drag Window
+    [self.window performWindowDragWithEvent:event];
+  }
+}
+
+- (void)updateTrackingAreas {
+  [self initTrackingArea];
+}
+
+-(void) initTrackingArea {
+  NSTrackingAreaOptions options = (NSTrackingActiveAlways | NSTrackingInVisibleRect |
+      NSTrackingMouseEnteredAndExited | NSTrackingMouseMoved);
+
+  NSTrackingArea *area = [[NSTrackingArea alloc] initWithRect:[self bounds]
+    options:options
+    owner:self
+    userInfo:nil];
+
+  [self addTrackingArea:area];
+}
+-(void)mouseEntered:(NSEvent *)event {
+  if((self.window.styleMask & NSWindowStyleMaskFullScreen) == 0) {
+    [[self.window standardWindowButton: NSWindowCloseButton] setHidden:NO];
+    [[self.window standardWindowButton: NSWindowMiniaturizeButton] setHidden:NO];
+    [[self.window standardWindowButton: NSWindowZoomButton] setHidden:NO];
+  }
+}
+
+-(void)mouseExited:(NSEvent *)event {
+  if((self.window.styleMask & NSWindowStyleMaskFullScreen) == 0) {
+    [[self.window standardWindowButton: NSWindowCloseButton] setHidden:YES];
+    [[self.window standardWindowButton: NSWindowMiniaturizeButton] setHidden:YES];
+    [[self.window standardWindowButton: NSWindowZoomButton] setHidden:YES];
+  }
+}
+
+@end
+
+extern "C" void showWindowTitleBarButtons(WId winId) {
+    if (winId == 0) return;
+    NSView* nativeView = reinterpret_cast<NSView*>(winId);
+    NSWindow* nativeWindow = [nativeView window];
+    [[nativeWindow standardWindowButton: NSWindowCloseButton] setHidden:NO];
+    [[nativeWindow standardWindowButton: NSWindowMiniaturizeButton] setHidden:NO];
+    [[nativeWindow standardWindowButton: NSWindowZoomButton] setHidden:NO];
+}
+
+extern "C" void hideWindowTitleBarButtons(WId winId) {
+    if (winId == 0) return;
+    NSView* nativeView = reinterpret_cast<NSView*>(winId);
+    NSWindow* nativeWindow = [nativeView window];
+    [[nativeWindow standardWindowButton: NSWindowCloseButton] setHidden:YES];
+    [[nativeWindow standardWindowButton: NSWindowMiniaturizeButton] setHidden:YES];
+    [[nativeWindow standardWindowButton: NSWindowZoomButton] setHidden:YES];
+}
+
+extern "C" void hideWindowTitleBar(WId winId) {
+    if (winId == 0) return;
+
+    NSView* nativeView = reinterpret_cast<NSView*>(winId);
+    NSWindow* nativeWindow = [nativeView window];
+
+    if(nativeWindow.titleVisibility == NSWindowTitleHidden){
+      return;
+    }
+
+    [[nativeWindow standardWindowButton: NSWindowCloseButton] setHidden:YES];
+    [[nativeWindow standardWindowButton: NSWindowMiniaturizeButton] setHidden:YES];
+    [[nativeWindow standardWindowButton: NSWindowZoomButton] setHidden:YES];
+    NSRect contentViewBounds = nativeWindow.contentView.bounds;
+
+    DraggableTitleView *titleBarView = [[DraggableTitleView alloc] initWithFrame:NSMakeRect(0, 0, contentViewBounds.size.width, 22)];
+    titleBarView.autoresizingMask = NSViewWidthSizable;
+    titleBarView.wantsLayer = YES;
+    titleBarView.layer.backgroundColor = [[NSColor clearColor] CGColor];
+
+    [nativeWindow.contentView addSubview:titleBarView];
+
+    [nativeWindow setTitleVisibility:NSWindowTitleHidden];
+    [nativeWindow setStyleMask:[nativeWindow styleMask] | NSWindowStyleMaskFullSizeContentView];
+    [nativeWindow setTitlebarAppearsTransparent:YES];
 }

--- a/pdf_viewer/main.cpp
+++ b/pdf_viewer/main.cpp
@@ -368,6 +368,7 @@ bool ADJUST_ANNOTATION_COLORS_FOR_DARK_MODE = true;
 
 #ifdef Q_OS_MACOS
 float MACOS_TITLEBAR_COLOR[3] = { -1.0f, -1.0f, -1.0f };
+bool MACOS_HIDE_TITLEBAR = false;
 #endif
 
 std::wstring RULER_DISPLAY_MODE = L"underline";


### PR DESCRIPTION
This commit introduces a new option `macos_hide_titlebar` to hide the titlebar on MacOS.

The window controls (close, minimize) are also hidden but will be show when the user hover over the top pixels of the window (where the titlebar would be if shown).

The titlebar is also hidden on the helper window.

In native fullscreen the window controls are shown as normal.

I'm not sure if you want to accept the pull request given the additional maintenance it might require. But the change is really small, most of it is some extra code to to deal with Cocoa windows. The actual code changes in the Qt part, is minimal. 

*Recording*


https://github.com/ahrm/sioyek/assets/167128/19224177-3fb7-4a90-8350-e037e016a431

