### PR TITLE
Improve hide MacOS titlebar

### DIFF
--- a/pdf_viewer/macos_specific.mm
+++ b/pdf_viewer/macos_specific.mm
@@ -17,65 +17,47 @@ extern "C" void changeTitlebarColor(WId winId, double red, double green, double 
 
 // Handle mouse click events
 - (void)mouseDown:(NSEvent *)event {
-  // double-click to zoom
-  if ([event clickCount] == 2) {
-    [self.window zoom:nil];
-  } else {
-    // drag Window
-    [self.window performWindowDragWithEvent:event];
-  }
+    // double-click to zoom
+    if ([event clickCount] == 2) {
+        [self.window zoom:nil];
+    } else {
+        // drag Window
+        [self.window performWindowDragWithEvent:event];
+    }
 }
 
 - (void)updateTrackingAreas {
-  [self initTrackingArea];
+    [self initTrackingArea];
 }
 
 -(void) initTrackingArea {
-  NSTrackingAreaOptions options = (NSTrackingActiveAlways | NSTrackingInVisibleRect |
-      NSTrackingMouseEnteredAndExited | NSTrackingMouseMoved);
+    NSTrackingAreaOptions options = (NSTrackingActiveAlways | NSTrackingInVisibleRect |
+            NSTrackingMouseEnteredAndExited | NSTrackingMouseMoved);
 
-  NSTrackingArea *area = [[NSTrackingArea alloc] initWithRect:[self bounds]
-    options:options
-    owner:self
-    userInfo:nil];
+    NSTrackingArea *area = [[NSTrackingArea alloc] initWithRect:[self bounds]
+        options:options
+        owner:self
+        userInfo:nil];
 
-  [self addTrackingArea:area];
+    [self addTrackingArea:area];
 }
 -(void)mouseEntered:(NSEvent *)event {
-  if((self.window.styleMask & NSWindowStyleMaskFullScreen) == 0) {
-    [[self.window standardWindowButton: NSWindowCloseButton] setHidden:NO];
-    [[self.window standardWindowButton: NSWindowMiniaturizeButton] setHidden:NO];
-    [[self.window standardWindowButton: NSWindowZoomButton] setHidden:NO];
-  }
+    if((self.window.styleMask & NSWindowStyleMaskFullScreen) == 0) {
+        [[self.window standardWindowButton: NSWindowCloseButton] setHidden:NO];
+        [[self.window standardWindowButton: NSWindowMiniaturizeButton] setHidden:NO];
+        [[self.window standardWindowButton: NSWindowZoomButton] setHidden:NO];
+    }
 }
 
 -(void)mouseExited:(NSEvent *)event {
-  if((self.window.styleMask & NSWindowStyleMaskFullScreen) == 0) {
-    [[self.window standardWindowButton: NSWindowCloseButton] setHidden:YES];
-    [[self.window standardWindowButton: NSWindowMiniaturizeButton] setHidden:YES];
-    [[self.window standardWindowButton: NSWindowZoomButton] setHidden:YES];
-  }
+    if((self.window.styleMask & NSWindowStyleMaskFullScreen) == 0) {
+        [[self.window standardWindowButton: NSWindowCloseButton] setHidden:YES];
+        [[self.window standardWindowButton: NSWindowMiniaturizeButton] setHidden:YES];
+        [[self.window standardWindowButton: NSWindowZoomButton] setHidden:YES];
+    }
 }
 
 @end
-
-extern "C" void showWindowTitleBarButtons(WId winId) {
-    if (winId == 0) return;
-    NSView* nativeView = reinterpret_cast<NSView*>(winId);
-    NSWindow* nativeWindow = [nativeView window];
-    [[nativeWindow standardWindowButton: NSWindowCloseButton] setHidden:NO];
-    [[nativeWindow standardWindowButton: NSWindowMiniaturizeButton] setHidden:NO];
-    [[nativeWindow standardWindowButton: NSWindowZoomButton] setHidden:NO];
-}
-
-extern "C" void hideWindowTitleBarButtons(WId winId) {
-    if (winId == 0) return;
-    NSView* nativeView = reinterpret_cast<NSView*>(winId);
-    NSWindow* nativeWindow = [nativeView window];
-    [[nativeWindow standardWindowButton: NSWindowCloseButton] setHidden:YES];
-    [[nativeWindow standardWindowButton: NSWindowMiniaturizeButton] setHidden:YES];
-    [[nativeWindow standardWindowButton: NSWindowZoomButton] setHidden:YES];
-}
 
 extern "C" void hideWindowTitleBar(WId winId) {
     if (winId == 0) return;
@@ -84,7 +66,7 @@ extern "C" void hideWindowTitleBar(WId winId) {
     NSWindow* nativeWindow = [nativeView window];
 
     if(nativeWindow.titleVisibility == NSWindowTitleHidden){
-      return;
+        return;
     }
 
     [[nativeWindow standardWindowButton: NSWindowCloseButton] setHidden:YES];

--- a/pdf_viewer/main_widget.cpp
+++ b/pdf_viewer/main_widget.cpp
@@ -98,8 +98,6 @@ extern "C" {
 #ifdef Q_OS_MACOS
 extern "C" void changeTitlebarColor(WId, double, double, double, double);
 extern "C" void hideWindowTitleBar(WId);
-extern "C" void showWindowTitleBarButtons(WId);
-extern "C" void hideWindowTitleBarButtons(WId);
 #endif
 
 extern int next_window_id;
@@ -1229,7 +1227,7 @@ MainWidget::MainWidget(fz_context* mupdf_context,
     }
 
     if (MACOS_HIDE_TITLEBAR) {
-      hideWindowTitleBar(winId());
+        hideWindowTitleBar(winId());
     }
     menu_bar = create_main_menu_bar();
     setMenuBar(menu_bar);
@@ -4075,7 +4073,7 @@ void MainWidget::apply_window_params_for_two_window_mode() {
 
 #ifdef Q_OS_MACOS
     if (MACOS_HIDE_TITLEBAR) {
-      hideWindowTitleBar(helper_window->winId());
+        hideWindowTitleBar(helper_window->winId());
     }
 #endif
     //int main_window_width = QApplication::desktop()->screenGeometry(0).width();
@@ -9767,7 +9765,7 @@ void MainWidget::initialize_helper(){
 #ifdef Q_OS_MACOS
     QWidget* helper_window = get_top_level_widget(helper_opengl_widget_);
     if (MACOS_HIDE_TITLEBAR) {
-      hideWindowTitleBar(helper_window->winId());
+        hideWindowTitleBar(helper_window->winId());
     }
     helper_opengl_widget_->show();
     helper_opengl_widget_->hide();


### PR DESCRIPTION
In response to my earlier PR (#1015)

- I've removed the unused code from the MacOS specific Cocoa-code (hide/show titlebar buttons), in response to your fix for compilation on other OS .

- I've corrected the indentation level of my previously committed code (which used 2 spaces).

Again, sorry for my mistakes in #1015.
