### PR TITLE
Automatically adjust colors depending on operating system theme

### DIFF
--- a/pdf_viewer/config.cpp
+++ b/pdf_viewer/config.cpp
@@ -27,6 +27,7 @@ extern bool SHOULD_DRAW_UNRENDERED_PAGES;
 extern bool HOVER_OVERVIEW;
 //extern bool AUTO_EMBED_ANNOTATIONS;
 extern bool DEFAULT_DARK_MODE;
+extern bool USE_SYSTEM_THEME;
 extern float HIGHLIGHT_COLORS[26 * 3];
 extern std::wstring SEARCH_URLS[26];
 extern std::wstring EXECUTE_COMMANDS[26];
@@ -703,6 +704,14 @@ ConfigManager::ConfigManager(const Path& default_path, const Path& auto_path, co
         L"default_dark_mode",
         ConfigType::Bool,
         &DEFAULT_DARK_MODE,
+        bool_serializer,
+        bool_deserializer,
+        bool_validator
+        });
+    configs.push_back({
+        L"use_system_theme",
+        ConfigType::Bool,
+        &USE_SYSTEM_THEME,
         bool_serializer,
         bool_deserializer,
         bool_validator

--- a/pdf_viewer/macos_specific.mm
+++ b/pdf_viewer/macos_specific.mm
@@ -17,65 +17,47 @@ extern "C" void changeTitlebarColor(WId winId, double red, double green, double 
 
 // Handle mouse click events
 - (void)mouseDown:(NSEvent *)event {
-  // double-click to zoom
-  if ([event clickCount] == 2) {
-    [self.window zoom:nil];
-  } else {
-    // drag Window
-    [self.window performWindowDragWithEvent:event];
-  }
+    // double-click to zoom
+    if ([event clickCount] == 2) {
+        [self.window zoom:nil];
+    } else {
+        // drag Window
+        [self.window performWindowDragWithEvent:event];
+    }
 }
 
 - (void)updateTrackingAreas {
-  [self initTrackingArea];
+    [self initTrackingArea];
 }
 
 -(void) initTrackingArea {
-  NSTrackingAreaOptions options = (NSTrackingActiveAlways | NSTrackingInVisibleRect |
-      NSTrackingMouseEnteredAndExited | NSTrackingMouseMoved);
+    NSTrackingAreaOptions options = (NSTrackingActiveAlways | NSTrackingInVisibleRect |
+            NSTrackingMouseEnteredAndExited | NSTrackingMouseMoved);
 
-  NSTrackingArea *area = [[NSTrackingArea alloc] initWithRect:[self bounds]
-    options:options
-    owner:self
-    userInfo:nil];
+    NSTrackingArea *area = [[NSTrackingArea alloc] initWithRect:[self bounds]
+        options:options
+        owner:self
+        userInfo:nil];
 
-  [self addTrackingArea:area];
+    [self addTrackingArea:area];
 }
 -(void)mouseEntered:(NSEvent *)event {
-  if((self.window.styleMask & NSWindowStyleMaskFullScreen) == 0) {
-    [[self.window standardWindowButton: NSWindowCloseButton] setHidden:NO];
-    [[self.window standardWindowButton: NSWindowMiniaturizeButton] setHidden:NO];
-    [[self.window standardWindowButton: NSWindowZoomButton] setHidden:NO];
-  }
+    if((self.window.styleMask & NSWindowStyleMaskFullScreen) == 0) {
+        [[self.window standardWindowButton: NSWindowCloseButton] setHidden:NO];
+        [[self.window standardWindowButton: NSWindowMiniaturizeButton] setHidden:NO];
+        [[self.window standardWindowButton: NSWindowZoomButton] setHidden:NO];
+    }
 }
 
 -(void)mouseExited:(NSEvent *)event {
-  if((self.window.styleMask & NSWindowStyleMaskFullScreen) == 0) {
-    [[self.window standardWindowButton: NSWindowCloseButton] setHidden:YES];
-    [[self.window standardWindowButton: NSWindowMiniaturizeButton] setHidden:YES];
-    [[self.window standardWindowButton: NSWindowZoomButton] setHidden:YES];
-  }
+    if((self.window.styleMask & NSWindowStyleMaskFullScreen) == 0) {
+        [[self.window standardWindowButton: NSWindowCloseButton] setHidden:YES];
+        [[self.window standardWindowButton: NSWindowMiniaturizeButton] setHidden:YES];
+        [[self.window standardWindowButton: NSWindowZoomButton] setHidden:YES];
+    }
 }
 
 @end
-
-extern "C" void showWindowTitleBarButtons(WId winId) {
-    if (winId == 0) return;
-    NSView* nativeView = reinterpret_cast<NSView*>(winId);
-    NSWindow* nativeWindow = [nativeView window];
-    [[nativeWindow standardWindowButton: NSWindowCloseButton] setHidden:NO];
-    [[nativeWindow standardWindowButton: NSWindowMiniaturizeButton] setHidden:NO];
-    [[nativeWindow standardWindowButton: NSWindowZoomButton] setHidden:NO];
-}
-
-extern "C" void hideWindowTitleBarButtons(WId winId) {
-    if (winId == 0) return;
-    NSView* nativeView = reinterpret_cast<NSView*>(winId);
-    NSWindow* nativeWindow = [nativeView window];
-    [[nativeWindow standardWindowButton: NSWindowCloseButton] setHidden:YES];
-    [[nativeWindow standardWindowButton: NSWindowMiniaturizeButton] setHidden:YES];
-    [[nativeWindow standardWindowButton: NSWindowZoomButton] setHidden:YES];
-}
 
 extern "C" void hideWindowTitleBar(WId winId) {
     if (winId == 0) return;
@@ -84,7 +66,7 @@ extern "C" void hideWindowTitleBar(WId winId) {
     NSWindow* nativeWindow = [nativeView window];
 
     if(nativeWindow.titleVisibility == NSWindowTitleHidden){
-      return;
+        return;
     }
 
     [[nativeWindow standardWindowButton: NSWindowCloseButton] setHidden:YES];

--- a/pdf_viewer/main.cpp
+++ b/pdf_viewer/main.cpp
@@ -199,6 +199,7 @@ bool FLAT_TABLE_OF_CONTENTS = false;
 bool SHOULD_USE_MULTIPLE_MONITORS = false;
 bool SHOULD_CHECK_FOR_LATEST_VERSION_ON_STARTUP = false;
 bool DEFAULT_DARK_MODE = false;
+bool USE_SYSTEM_THEME = false;
 bool SORT_BOOKMARKS_BY_LOCATION = true;
 std::wstring LIBGEN_ADDRESS = L"";
 std::wstring GOOGLE_SCHOLAR_ADDRESS = L"";
@@ -1144,7 +1145,7 @@ int main(int argc, char* args[]) {
         });
 #endif
 
-    if (DEFAULT_DARK_MODE) {
+    if (DEFAULT_DARK_MODE && !USE_SYSTEM_THEME) {
         main_widget->toggle_dark_mode();
     }
 

--- a/pdf_viewer/main_widget.cpp
+++ b/pdf_viewer/main_widget.cpp
@@ -98,8 +98,6 @@ extern "C" {
 #ifdef Q_OS_MACOS
 extern "C" void changeTitlebarColor(WId, double, double, double, double);
 extern "C" void hideWindowTitleBar(WId);
-extern "C" void showWindowTitleBarButtons(WId);
-extern "C" void hideWindowTitleBarButtons(WId);
 #endif
 
 extern int next_window_id;
@@ -1229,7 +1227,7 @@ MainWidget::MainWidget(fz_context* mupdf_context,
     }
 
     if (MACOS_HIDE_TITLEBAR) {
-      hideWindowTitleBar(winId());
+        hideWindowTitleBar(winId());
     }
     menu_bar = create_main_menu_bar();
     setMenuBar(menu_bar);
@@ -4075,7 +4073,7 @@ void MainWidget::apply_window_params_for_two_window_mode() {
 
 #ifdef Q_OS_MACOS
     if (MACOS_HIDE_TITLEBAR) {
-      hideWindowTitleBar(helper_window->winId());
+        hideWindowTitleBar(helper_window->winId());
     }
 #endif
     //int main_window_width = QApplication::desktop()->screenGeometry(0).width();
@@ -9767,7 +9765,7 @@ void MainWidget::initialize_helper(){
 #ifdef Q_OS_MACOS
     QWidget* helper_window = get_top_level_widget(helper_opengl_widget_);
     if (MACOS_HIDE_TITLEBAR) {
-      hideWindowTitleBar(helper_window->winId());
+        hideWindowTitleBar(helper_window->winId());
     }
     helper_opengl_widget_->show();
     helper_opengl_widget_->hide();

--- a/pdf_viewer/main_widget.h
+++ b/pdf_viewer/main_widget.h
@@ -389,6 +389,7 @@ public:
     void set_dark_mode();
     void set_light_mode();
     void set_custom_color_mode();
+    void set_system_mode();
     void toggle_statusbar();
     void toggle_titlebar();
 


### PR DESCRIPTION
This PR allows Sioyek to automatically adjust the color mode (dark/light) depending on the operating system theme.

Uses a configuration option `use_system_theme` to enable it. I made it so that if `use_system_theme` is set `default_dark_mode` is not used but I suppose that's up for debate.

**NOTE**: I've only tested the code on MacOS but it uses `QEvent::ThemeChange` (available in Qt 6.5.0 and above) so it should be portable to other operating system. I don't have access to another machine so I'm unable to test currently.

This is stacked on #1021 (#1021 should be merged first - then I can rebase this PR)


https://github.com/ahrm/sioyek/assets/167128/9af02140-2555-44e2-b73f-945e3870d948

