### PR TITLE
Fix crash when selecting link using characters

### DIFF
--- a/pdf_viewer/main_widget.cpp
+++ b/pdf_viewer/main_widget.cpp
@@ -3896,8 +3896,9 @@ std::optional<std::pair<int, fz_link*>> MainWidget::get_selected_link(const std:
 		if ((link_index >= 0) && (link_index < static_cast<int>(visible_page_links.size()))) {
             return visible_page_links[link_index];
 		}
-        return {};
 	}
+
+    return {};
 }
 
 void MainWidget::handle_overview_link(const std::wstring& text) {


### PR DESCRIPTION
This PR fixes a crash observed when selecting a link using a character.

The issue occurs in `MainWidget::get_selected_link()` when `is_string_number` returns `false` and `ALPHABETIC_LINK_TAGS` is also set to `false`. In that case, no return is produced from the function for the `std::optional`, which is undefined behaviour causing a crash in my case.

The fix is simply to return a default-initialized `std::optional` in all cases.

Steps to reproduce issue:
1. Open link
2. Press `n` or some other text key.

This yields the following gdb trace:
```
Thread 1 "sioyek" received signal SIGSEGV, Segmentation fault.
0x00007ffff6715503 in _Unwind_Resume (exc=0x0) at ../../../libgcc/unwind.inc:241
241       if (exc->private_1 == 0)
(gdb) bt
#0  0x00007ffff6715503 in _Unwind_Resume (exc=0x0) at ../../../libgcc/unwind.inc:241
#1  0x00000000004271a0 in MainWidget::get_selected_link(std::__cxx11::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t> > const&) [clone .cold] ()
#2  0x00000000004b0954 in MainWidget::handle_open_link(std::__cxx11::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t> > const&, bool) ()
#3  0x00000000004ae168 in MainWidget::advance_command(std::unique_ptr<Command, std::default_delete<Command> >) ()
#4  0x00000000004afcb4 in MainWidget::key_event(bool, QKeyEvent*) ()
#5  0x00007ffff77f43f5 in QWidget::event (this=0x335dd80, event=0x7fffffffc370) at kernel/qwidget.cpp:8704
#6  0x00007ffff77aeb95 in QApplicationPrivate::notify_helper
    (this=this@entry=0x2b074d0, receiver=receiver@entry=0x335dd80, e=e@entry=0x7fffffffc370) at kernel/qapplication.cpp:3640
#7  0x00007ffff77b6f39 in QApplication::notify (this=<optimized out>, receiver=0x335dd80, e=0x7fffffffc370) at kernel/qapplication.cpp:3002
#8  0x00007ffff6ab4e78 in QCoreApplication::notifyInternal2 (receiver=0x335dd80, event=0x7fffffffc370) at kernel/qcoreapplication.cpp:1064
#9  0x00007ffff6ab4ec6 in QCoreApplication::forwardEvent (receiver=<optimized out>, event=<optimized out>, originatingEvent=<optimized out>)
    at kernel/qcoreapplication.cpp:1079
#10 0x00007ffff781075a in QWidgetWindow::event (this=0x351dee0, event=0x7fffffffc370) at kernel/qwidgetwindow.cpp:293
#11 0x00007ffff77aeb95 in QApplicationPrivate::notify_helper (this=<optimized out>, receiver=0x351dee0, e=0x7fffffffc370)
    at kernel/qapplication.cpp:3640
q#12 0x00007ffff6ab4e78 in QCoreApplication::notifyInternal2 (receiver=0x351dee0, event=0x7fffffffc370) at kernel/qcoreapplication.cpp:1064
#13 0x00007ffff6ab50b2 in QCoreApplication::sendSpontaneousEvent (receiver=<optimized out>, event=<optimized out>)
    at kernel/qcoreapplication.cpp:1474
#14 0x00007ffff6f69053 in QGuiApplicationPrivate::processKeyEvent (e=0x436ea70) at kernel/qguiapplication.cpp:2410
#15 0x00007ffff6f4ad4c in QWindowSystemInterface::sendWindowSystemEvents (flags=...) at kernel/qwindowsysteminterface.cpp:1169
#16 0x00007ffff26e1fa4 in userEventSourceDispatch(_GSource*, int (*)(void*), void*) () at /lib64/libQt5WaylandClient.so.5
#17 0x00007ffff612fe5c in g_main_dispatch (context=0x7fffe0000ec0) at ../glib/gmain.c:3476
#18 g_main_context_dispatch_unlocked (context=0x7fffe0000ec0) at ../glib/gmain.c:4284
#19 0x00007ffff618af18 in g_main_context_iterate_unlocked.isra.0
    (context=context@entry=0x7fffe0000ec0, block=block@entry=1, dispatch=dispatch@entry=1, self=<optimized out>) at ../glib/gmain.c:4349
#20 0x00007ffff612dad3 in g_main_context_iteration (context=0x7fffe0000ec0, may_block=1) at ../glib/gmain.c:4414
#21 0x00007ffff6b073b9 in QEventDispatcherGlib::processEvents (this=0x2b53dc0, flags=...) at kernel/qeventdispatcher_glib.cpp:423
#22 0x00007ffff6ab383b in QEventLoop::exec (this=this@entry=0x7fffffffc680, flags=..., flags@entry=...)
    at ../../include/QtCore/../../src/corelib/global/qflags.h:69
#23 0x00007ffff6abbacb in QCoreApplication::exec () at ../../include/QtCore/../../src/corelib/global/qflags.h:121
#24 0x000000000042d6ff in main ()
```