### PR TITLE
`visual_mark_next_page_threshold` is at center when 1, and top/bottom when zero

### DIFF
--- a/pdf_viewer/prefs.config
+++ b/pdf_viewer/prefs.config
@@ -74,7 +74,7 @@ should_launch_new_window				0
 # When moving to the next line using visual marker, this setting specifies the distance of the market to the top of the screen in fractions of screen size (center of the screen is zero, top of the screen is one)
 visual_mark_next_page_fraction	0.75
 
-# When moving to the next line using visual marker, this setting determines at which point we move the screen (center of the screen is zero, bottom of the screen is one)
+# When moving to the next line using visual marker, this setting determines at which point we move the screen (center of the screen is one, bottom of the screen is zero)
 visual_mark_next_page_threshold	0.25
 
 # If set, we display a checkerboard pattern for unrendered pages (by default we display nothing)


### PR DESCRIPTION
hinted to here too: https://github.com/ahrm/sioyek/issues/889#issuecomment-1854369371

Kindly confirm