### PR TITLE
Declare epub support

### DIFF
--- a/resources/sioyek.desktop
+++ b/resources/sioyek.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Sioyek
 Comment=PDF viewer for reading research papers and technical books
-Keywords=pdf;viewer;reader;research;
+Keywords=pdf;viewer;reader;research;epub;
 TryExec=sioyek
 Exec=sioyek %f
 StartupNotify=true
@@ -9,4 +9,4 @@ Terminal=false
 Type=Application
 Icon=sioyek-icon-linux
 Categories=Development;Viewer;
-MimeType=application/pdf;
+MimeType=application/pdf;application/epub+zip;


### PR DESCRIPTION
Sioyek isn't shown as a possibility when trying to open an epub this should help with that

Ref: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types