### PR TITLE
Fix typo in Runguard::sendMessage function

### DIFF
--- a/pdf_viewer/RunGuard.cpp
+++ b/pdf_viewer/RunGuard.cpp
@@ -134,7 +134,7 @@ std::string RunGuard::sendMessage(const QByteArray& message, bool wait)
     }
     else {
         qCritical() << "Secondary application cannot connect to IPC server.";
-        qCritical() << "Socker error: " << socket.error();
+        qCritical() << "Socket error: " << socket.error();
         QCoreApplication::exit();
     }
     return "";


### PR DESCRIPTION
Tiny pull request to fix typo in error message when trying to start second `sioyek` instance from command line.
<pre>
 $	sioyek
default_config_path: /tmp/.mount_sioyek8iSwV7/usr/bin/prefs.config
default_keys_path: /tmp/.mount_sioyek8iSwV7/usr/bin/keys.config
user_config_path: [ 0 ] /etc/xdg/sioyek/prefs_user.config
user_config_path: [ 1 ] /home/iris/.config/sioyek/prefs_user.config
user_config_path: [ 2 ] /home/iris/.local/share/Sioyek/prefs_user.config
user_config_path: [ 3 ] /home/iris/.config/sioyek/prefs_user.config
user_keys_path: [ 0 ] /etc/xdg/sioyek/keys_user.config
user_keys_path: [ 1 ] /home/iris/.config/sioyek/keys_user.config
user_keys_path: [ 2 ] /home/iris/.local/share/Sioyek/keys_user.config
user_keys_path: [ 3 ] /home/iris/.config/sioyek/keys_user.config
database_file_path: /home/iris/.local/share/Sioyek/test.db
local_database_file_path: /home/iris/.local/share/Sioyek/local.db
global_database_file_path: /home/iris/.local/share/Sioyek/shared.db
tutorial_path: /home/iris/.local/share/Sioyek/tutorial.pdf
last_opened_file_address_path: /home/iris/.local/share/Sioyek/last_document_path.txt
shader_path: /tmp/.mount_sioyek8iSwV7/usr/bin/shaders
Creating shared memory block...
Shared memory already exists: this is a secondary application.
Secondary application attaching to shared memory block...
Secondary application successfully attached to shared memory block.
Secondary application cannot connect to IPC server.
<b>Socker</b> error:  QLocalSocket::ConnectionRefusedError
</pre>
On the last line I think it should print <pre><b>Socket</b> error:  QLocalSocket::ConnectionRefusedError</pre> instead of `Socker error:  QLocalSocket::ConnectionRefusedError`