### PR TITLE
Add functionality for checking for a new version

### DIFF
--- a/pdf_viewer/utils.cpp
+++ b/pdf_viewer/utils.cpp
@@ -2048,7 +2048,6 @@ void check_for_updates(QWidget* parent, std::string current_version) {
             }
 
             std::string version_from_latest_release = reply_url.substr(expected_resolved_url_start.length(), reply_url.length() - 1);
-            version_from_latest_release = "69.420.0";
             if (version_from_latest_release != current_version) {
             int ret = QMessageBox::information(parent, "Update",
                     QString::fromStdString( "New version of sioyek is available.\nDo you want to update from version "


### PR DESCRIPTION
There was a commented out code for this functionality in utils.cpp, but when I tested that code it would evaluate the version wrong. 
I tried to add a way to check if a new version available from the github releases. If so it redirects to the github release site. 
If there's something I overlooked, I'd appreciate feedback, thanks.

I added a test case(it emulates when there's a new version) where the version obtained from  github releases(69.420.0) is different than current version(2.0.0). It works as expected.
![image](https://github.com/ahrm/sioyek/assets/55573157/2076fdec-dfb8-4f18-af8b-3740fd8a40b9)


