### PR TITLE
Change how goto_beginning, goto_top handle scrolling

### DIFF
--- a/pdf_viewer/document_view.cpp
+++ b/pdf_viewer/document_view.cpp
@@ -441,10 +441,18 @@ void DocumentView::goto_mark(char symbol) {
 		}
 	}
 }
+
+void DocumentView::goto_beginning() {
+	if (current_document) {
+		goto_page(0);
+        }
+}
+
 void DocumentView::goto_end() {
 	if (current_document) {
-		int last_page_index = current_document->num_pages() - 1;
-		set_offset_y(current_document->get_accum_page_height(last_page_index) + current_document->get_page_height(last_page_index));
+		int last_page_index = current_document->num_pages()-1;
+		goto_page(last_page_index);
+		goto_bottom_of_page();
 	}
 }
 

--- a/pdf_viewer/document_view.h
+++ b/pdf_viewer/document_view.h
@@ -106,6 +106,7 @@ public:
 	NormalizedWindowPos window_to_normalized_window_pos(WindowPos window_pos);
 	void goto_mark(char symbol);
 	void goto_end();
+	void goto_beginning();
 
 	void goto_left();
 	void goto_left_smart();

--- a/pdf_viewer/input.cpp
+++ b/pdf_viewer/input.cpp
@@ -2310,7 +2310,6 @@ CommandManager::CommandManager(ConfigManager* config_manager) {
 	new_commands["focus_text"] = []() {return std::make_unique< FocusTextCommand>(); };
 	new_commands["goto_window"] = []() {return std::make_unique< GotoWindowCommand>(); };
 	new_commands["toggle_smooth_scroll_mode"] = []() {return std::make_unique< ToggleSmoothScrollModeCommand>(); };
-	new_commands["goto_begining"] = []() {return std::make_unique< GotoBeginningCommand>(); };
 	new_commands["toggle_scrollbar"] = []() {return std::make_unique< ToggleScrollbarCommand>(); };
 	new_commands["overview_to_portal"] = []() {return std::make_unique< OverviewToPortalCommand>(); };
 	new_commands["select_rect"] = []() {return std::make_unique< SelectRectCommand>(); };

--- a/pdf_viewer/input.cpp
+++ b/pdf_viewer/input.cpp
@@ -740,7 +740,7 @@ public:
 			main_widget->main_document_view->goto_page(num_repeats - 1 + main_widget->main_document_view->get_page_offset());
 		}
 		else {
-			main_widget->main_document_view->set_offset_y(0.0f);
+			main_widget->main_document_view->goto_beginning();
 		}
 	}
 

--- a/pdf_viewer/input.cpp
+++ b/pdf_viewer/input.cpp
@@ -737,7 +737,7 @@ class GotoBeginningCommand : public Command {
 public:
 	void perform(MainWidget* main_widget) {
 		if (num_repeats) {
-			main_widget->main_document_view->goto_page(num_repeats - 1 + main_widget->main_document_view->get_page_offset());
+			main_widget->main_document_view->goto_page(num_repeats + main_widget->main_document_view->get_page_offset());
 		}
 		else {
 			main_widget->main_document_view->goto_beginning();
@@ -756,8 +756,10 @@ public:
 class GotoEndCommand : public Command {
 public:
 	void perform(MainWidget* main_widget) {
+		int num_pages = main_widget->main_document_view->get_document()->num_pages()-1;
 		if (num_repeats > 0) {
-			main_widget->main_document_view->goto_page(num_repeats - 1 + main_widget->main_document_view->get_page_offset());
+			main_widget->main_document_view->goto_page(num_pages - num_repeats);
+			main_widget->main_document_view->goto_bottom_of_page();
 		}
 		else {
 			main_widget->main_document_view->goto_end();

--- a/scripts/sioyek-generator.py
+++ b/scripts/sioyek-generator.py
@@ -2,7 +2,7 @@
 script used to generate sioyek.py file
 '''
 sioyek_commands = {
-    "goto_begining": [False,	False,	False,	True],
+    "goto_beginning": [False,	False,	False,	True],
     "goto_end": [False,	False,	False,	True],
     "goto_definition": [False,	False,	False,	False],
     "overview_definition": [False,	False,	False,	False],

--- a/scripts/sioyek.py
+++ b/scripts/sioyek.py
@@ -83,9 +83,9 @@ class Sioyek:
         else:
             subprocess.run(params)
 
-    def goto_begining(self, focus=False):
+    def goto_beginning(self, focus=False):
         data = None
-        self.run_command("goto_begining", data, focus=focus)
+        self.run_command("goto_beginning", data, focus=focus)
 
     def goto_end(self, focus=False):
         data = None

--- a/scripts/summary_highlight_server.py
+++ b/scripts/summary_highlight_server.py
@@ -31,7 +31,7 @@ def decode(outputs_ids):
 
 def roll_encoding(encoding):
     # by default if encodings are smaller than maximum length, they are padded with
-    # zeroes at the end. We need the zero padding to be at the begining for next
+    # zeroes at the end. We need the zero padding to be at the beginning for next
     # character prediction to work
     new_encoding = torch.clone(encoding)
     num_rows = encoding.shape[0]


### PR DESCRIPTION
Similar to the  issue in #1039 but not quite the same since this PR only affects the commands. 
Currently when navigating to the top/bottom of the page using keyboard or entering command, sioyek will scroll past the page edge, I found this bothersome and I see no benefit to scrolling past the page like that.  

* This changes the way sioyek handles going to the top and bottom of the page with gg and G, or goto_end and goto_beginning commands.
   - Scrolling to the top with gg/ goto_beginning will now stop the page absolutely at the top of the screen
   - Similarly when scrolling to the bottom with G, goto_end, the page will not scroll past the bottom edge
* Changed the way numer repeats offsets the page, 
    - Ex. 0gg is equivalent to gg, 1gg is one page from the top i.e. page 2, 2gg is page 3 ... e.t.c
    - Same for scrolling to bottom, 0G is same as G, 1G is next to last page e.t.c   
* Fix the 'begining' typo in some functions

