### PR TITLE
fix #1144, focus window on macOS

### DIFF
--- a/pdf_viewer/main_widget.cpp
+++ b/pdf_viewer/main_widget.cpp
@@ -1968,6 +1968,7 @@ void MainWidget::open_document(const Path& path, std::optional<float> offset_x, 
         }
         update_scrollbar();
     }
+    focus_on_widget(this);
 
     deselect_document_indices();
     invalidate_render();

--- a/pdf_viewer/utils.h
+++ b/pdf_viewer/utils.h
@@ -56,6 +56,8 @@ int argminf(const std::vector<T>& collection, std::function<float(T)> f) {
     }
     return min_index;
 }
+
+void focus_on_widget(QWidget* widget);
 void rect_to_quad(fz_rect rect, float quad[8]);
 void copy_to_clipboard(const std::wstring& text, bool selection = false);
 void install_app(const char* argv0);


### PR DESCRIPTION
Fix #1144: In macOS, when opening sioyek in full-screen mode, opening a file can still focus on the window