### PR TITLE
Introduce named instances

### DIFF
--- a/pdf_viewer/main.cpp
+++ b/pdf_viewer/main.cpp
@@ -721,7 +721,8 @@ int main(int argc, char* args[]) {
     }
 
 #ifndef SIOYEK_ANDROID
-    RunGuard guard("sioyek");
+    char* instance_name = get_argv_value(argc, args, "--instance-name");
+    RunGuard guard(instance_name ? instance_name : "sioyek");
     if (!guard.isPrimary()) {
         QStringList sent_args = convert_arguments(app.arguments());
         bool should_wait = parser->isSet("wait-for-response");

--- a/pdf_viewer/utils.cpp
+++ b/pdf_viewer/utils.cpp
@@ -1869,6 +1869,9 @@ QCommandLineParser* get_command_line_parser() {
     //new_instance_option.setDescription("When opening a new file, create a new instance of sioyek.");
     //parser->addOption(new_instance_option);
 
+    QCommandLineOption instance_name_option("instance-name", "Select a specific sioyek instance by name.", "name");
+    parser->addOption(instance_name_option);
+
     QCommandLineOption new_window_option("new-window");
     new_window_option.setDescription("Open the file in a new window but within the same sioyek instance (reuses the previous window if a sioyek window with the same file already exists).");
     parser->addOption(new_window_option);

--- a/resources/sioyek.1
+++ b/resources/sioyek.1
@@ -691,6 +691,10 @@ is set in a preference file (see below), then open a tutorial PDF.
 
 Displays version information
 .HP
+.B --instance-name
+
+Select a specific sioyek instance by name.
+.HP
 .B --new-window
 
 Open the file in a new window but within the same sioyek instance.


### PR DESCRIPTION
This allows controlling specific instances when using multiple instances, e.g. one for reading and another one for synctex.