### PR TITLE
Refactor compiler diagnostics and deprecations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,8 @@ qt_add_executable(sioyek WIN32 MACOSX_BUNDLE
     pdf_viewer/utils.cpp pdf_viewer/utils.h
 )
 
+target_compile_options(sioyek PRIVATE -Wno-inconsistent-missing-override)
+
 target_include_directories(sioyek PRIVATE 
     pdf_viewer 
     ${SQLite3_INCLUDE_DIRS}

--- a/pdf_viewer/database.cpp
+++ b/pdf_viewer/database.cpp
@@ -1,4 +1,4 @@
-#include "database.h";
+#include "database.h"
 #include <sstream>
 #include <cassert>
 #include <utility>
@@ -1880,7 +1880,7 @@ std::wstring encode_variant(QVariant var) {
 
 
     std::vector<QString> specials = { "CURRENT_TIMESTAMP", "datetime('now')" };
-    if ((var.type() == QVariant::String) || (var.type() == QVariant::Char)) {
+    if ((var.typeId() == QMetaType::QString) || (var.typeId() == QMetaType::Char)) {
         if (std::find(specials.begin(), specials.end(), var.toString()) != specials.end()) {
             return var.toString().toStdWString();
         }

--- a/pdf_viewer/document.cpp
+++ b/pdf_viewer/document.cpp
@@ -1608,7 +1608,7 @@ std::optional<std::pair<std::wstring, std::wstring>> Document::get_generic_link_
     std::pair<int,
     int>* out_range) {
 
-    std::wregex regex(L"[a-zA-Z]{3,}(\.){0,1}[ \t]+[0-9]+(\.[0-9]+)*");
+    std::wregex regex(L"[a-zA-Z]{3,}(\\.){0,1}[ \t]+[0-9]+(\\.[0-9]+)*");
     std::optional<std::wstring> match_string = get_regex_match_at_position(regex, flat_chars, position, out_range);
     if (match_string) {
         std::vector<std::wstring> parts = split_whitespace(match_string.value());
@@ -1985,7 +1985,7 @@ void Document::get_text_selection(fz_context* ctx, AbsoluteDocumentPos selection
                     selected_text.push_back(current_char->c);
                     selected_characters.push_back(to_absolute(i, current_char->quad));
                 }
-                if ((current_char->next == nullptr)) {
+                if (current_char->next == nullptr) {
                     if (current_char->c != '-')
                     {
                         selected_text.push_back(' ');
@@ -2843,7 +2843,7 @@ const std::vector<AbsoluteRect>& Document::get_page_lines(
         }
         else {
             fz_pixmap* pixmap = get_small_pixmap(page);
-            if (pixmap == nullptr) return {};
+            if (pixmap == nullptr) return std::vector<AbsoluteRect>();
             std::vector<unsigned int> hist = get_max_width_histogram_from_pixmap(pixmap);
             std::vector<unsigned int> line_locations;
             std::vector<unsigned int> line_locations_begins;
@@ -4040,7 +4040,7 @@ std::optional<DocumentPos> Document::find_abbreviation(std::wstring abbr, std::v
 
 int Document::find_reference_page_with_reference_text(std::wstring ref) {
 
-    QStringList parts = QString::fromStdWString(ref).split(QRegularExpression("[ \w\(\);,]"));
+    QStringList parts = QString::fromStdWString(ref).split(QRegularExpression("[ \\w\\(\\);,]"));
     QString largest_part = "";
     for (int i = 0; i < parts.size(); i++) {
         if (parts.at(i).size() > largest_part.size() ) {
@@ -4250,7 +4250,7 @@ int Document::get_page_text_and_line_rects_after_rect(int page_number,
                 line_rects.push_back(line->bbox);
                 char_rects.push_back(fz_rect_from_quad(chr->quad));
 
-                if ((chr->next == nullptr)) {
+                if (chr->next == nullptr) {
                     text.push_back(' ');
 
                     line_rects.push_back(line->bbox);

--- a/pdf_viewer/document_view.cpp
+++ b/pdf_viewer/document_view.cpp
@@ -405,6 +405,8 @@ NormalizedWindowPos DocumentView::document_to_window_pos(DocumentPos doc_pos) {
         float window_y = static_cast<float>((window_pos.y - halfheight) / halfheight);
         return { window_x, -window_y };
     }
+
+    return { 0, 0 };
 }
 
 WindowPos DocumentView::absolute_to_window_pos_in_pixels(AbsoluteDocumentPos abspos) {
@@ -1337,7 +1339,7 @@ std::vector<SmartViewCandidate> DocumentView::find_line_definitions() {
                 return result;
             }
 
-            std::wstring item_regex(L"[a-zA-Z]{2,}\\.?[ \t]+[0-9]+(\.[0-9]+)*");
+            std::wstring item_regex(L"[a-zA-Z]{2,}\\.?[ \t]+[0-9]+(\\.?[0-9]+)*");
             std::wstring reference_regex(L"\\[[a-zA-Z0-9, ]+\\]");
             std::wstring equation_regex(L"\\([0-9]+(\\.[0-9]+)*\\)");
 

--- a/pdf_viewer/input.cpp
+++ b/pdf_viewer/input.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <optional>
 #include <vector>
 #include <string>
 #include <fstream>
@@ -152,6 +153,7 @@ struct ParseState {
             }
             return arg;
         }
+        return std::nullopt;
     }
 
     bool is_valid_command_name_char(QChar c) {
@@ -259,14 +261,14 @@ private:
         return {};
     }
 
-    void set_result_socket(QLocalSocket* socket) {
+    void set_result_socket(QLocalSocket* socket) override {
         result_socket = socket;
         if (actual_command) {
             actual_command->set_result_socket(socket);
         }
     }
 
-    void set_result_mutex(bool* p_is_done, std::wstring* result_location) {
+    void set_result_mutex(bool* p_is_done, std::wstring* result_location) override {
         result_holder = result_location;
         is_done = p_is_done;
         if (actual_command) {
@@ -310,30 +312,30 @@ public:
         //parse_command_text(command_text);
     }
 
-    void set_text_requirement(std::wstring value) { get_command()->set_text_requirement(value); }
-    void set_symbol_requirement(char value) { get_command()->set_symbol_requirement(value); }
-    void set_file_requirement(std::wstring value) { get_command()->set_file_requirement(value); }
-    void set_rect_requirement(AbsoluteRect value) { get_command()->set_rect_requirement(value); }
-    void set_generic_requirement(QVariant value) { get_command()->set_generic_requirement(value); }
-    void handle_generic_requirement() { get_command()->handle_generic_requirement(); }
-    void set_point_requirement(AbsoluteDocumentPos value) { get_command()->set_point_requirement(value); }
-    void set_num_repeats(int nr) { get_command()->set_num_repeats(nr); }
-    std::vector<char> special_symbols() { return get_command()->special_symbols(); }
-    void pre_perform() { get_command()->pre_perform(); }
-    bool pushes_state() { return get_command()->pushes_state(); }
-    bool requires_document() { return get_command()->requires_document(); }
-    std::optional<Requirement> next_requirement(MainWidget* widget) {
+    void set_text_requirement(std::wstring value) override { get_command()->set_text_requirement(value); }
+    void set_symbol_requirement(char value) override { get_command()->set_symbol_requirement(value); }
+    void set_file_requirement(std::wstring value) override { get_command()->set_file_requirement(value); }
+    void set_rect_requirement(AbsoluteRect value) override { get_command()->set_rect_requirement(value); }
+    void set_generic_requirement(QVariant value) override { get_command()->set_generic_requirement(value); }
+    void handle_generic_requirement() override { get_command()->handle_generic_requirement(); }
+    void set_point_requirement(AbsoluteDocumentPos value) override { get_command()->set_point_requirement(value); }
+    void set_num_repeats(int nr) override { get_command()->set_num_repeats(nr); }
+    std::vector<char> special_symbols() override { return get_command()->special_symbols(); }
+    void pre_perform() override { get_command()->pre_perform(); }
+    bool pushes_state() override { return get_command()->pushes_state(); }
+    bool requires_document() override { return get_command()->requires_document(); }
+    std::optional<Requirement> next_requirement(MainWidget* widget) override {
         return get_command()->next_requirement(widget);
     }
 
-    virtual void perform() {
+    virtual void perform() override {
         auto com = get_command();
         if (com) {
             com->run();
         }
     }
 
-    std::string get_name() {
+    std::string get_name() override  {
         auto com = get_command();
         if (com) {
             return com->get_name();
@@ -373,14 +375,14 @@ public:
         }
     }
 
-    void set_result_socket(QLocalSocket* rsocket) {
+    void set_result_socket(QLocalSocket* rsocket) override {
         result_socket = rsocket;
         for (auto& subcommand : commands) {
             subcommand->set_result_socket(result_socket);
         }
     }
 
-    void set_result_mutex(bool* id, std::wstring* result_location) {
+    void set_result_mutex(bool* id, std::wstring* result_location) override {
         is_done = id;
         result_holder = result_location;
         for (auto& subcommand : commands) {
@@ -438,7 +440,7 @@ public:
         return {};
     }
 
-    void set_text_requirement(std::wstring value) {
+    void set_text_requirement(std::wstring value) override {
         if (is_modal) {
             int current_mode_index = get_current_mode_index();
             if (current_mode_index >= 0) {
@@ -458,7 +460,7 @@ public:
         }
     }
 
-    bool is_menu_command() {
+    bool is_menu_command() override {
         if (is_modal) {
             bool res = false;
             for (std::string mode : modes) {
@@ -471,7 +473,7 @@ public:
         return false;
     }
 
-    void set_generic_requirement(QVariant value) {
+    void set_generic_requirement(QVariant value) override {
         if (is_modal) {
             int current_mode_index = get_current_mode_index();
             if (current_mode_index >= 0) {
@@ -491,7 +493,7 @@ public:
         }
     }
 
-    void handle_generic_requirement() {
+    void handle_generic_requirement() override {
         if (is_modal) {
             int current_mode_index = get_current_mode_index();
             if (current_mode_index >= 0) {
@@ -511,7 +513,7 @@ public:
         }
     }
 
-    void set_symbol_requirement(char value) {
+    void set_symbol_requirement(char value) override {
         if (is_modal) {
             int current_mode_index = get_current_mode_index();
             if (current_mode_index >= 0) {
@@ -532,7 +534,7 @@ public:
         }
     }
 
-    bool requires_document() {
+    bool requires_document() override {
         if (is_modal) {
             int current_mode_index = get_current_mode_index();
             if (current_mode_index >= 0) {
@@ -548,9 +550,10 @@ public:
             }
             return false;
         }
+        return false;
     }
 
-    void set_file_requirement(std::wstring value) {
+    void set_file_requirement(std::wstring value) override {
         if (is_modal) {
             int current_mode_index = get_current_mode_index();
             if (current_mode_index >= 0) {
@@ -589,14 +592,14 @@ public:
         return -1;
     }
 
-    void set_rect_requirement(AbsoluteRect value) {
+    void set_rect_requirement(AbsoluteRect value) override {
         int index = get_command_index_for_requirement_type(RequirementType::Rect);
         if (index >= 0) {
             commands[index]->set_rect_requirement(value);
         }
     }
 
-    void set_point_requirement(AbsoluteDocumentPos value) {
+    void set_point_requirement(AbsoluteDocumentPos value) override {
         int index = get_command_index_for_requirement_type(RequirementType::Point);
         if (index >= 0) {
             commands[index]->set_point_requirement(value);
@@ -604,7 +607,7 @@ public:
     }
 
 
-    void pre_perform() {
+    void pre_perform() override {
         if (is_modal) {
             int current_mode_index = get_current_mode_index();
             if (current_mode_index >= 0) {
@@ -621,7 +624,7 @@ public:
         }
     }
 
-    std::optional<Requirement> next_requirement(MainWidget* widget) {
+    std::optional<Requirement> next_requirement(MainWidget* widget) override {
         if (is_modal && (modes.size() != commands.size())) {
             std::wcerr << L"Invalid modal command : " << raw_commands;
             return {};
@@ -688,7 +691,7 @@ public:
 
     }
 
-    void perform() {
+    void perform() override {
         if (!is_modal) {
             for (int i = 0; i < commands.size(); i++) {
 
@@ -743,7 +746,7 @@ public:
     }
 
 
-    void on_text_change(const QString& new_text) {
+    void on_text_change(const QString& new_text) override {
         if (is_modal) {
             int mode_index = get_current_mode_index();
             if (mode_index != -1) {
@@ -757,7 +760,7 @@ public:
         }
     }
 
-    std::vector<char> special_symbols() {
+    std::vector<char> special_symbols() override {
         int command_index = get_current_executing_command_index();
         if (command_index != -1) {
             return commands[command_index]->special_symbols();
@@ -774,7 +777,7 @@ public:
         return true;
     }
 
-    std::string get_name() {
+    std::string get_name() override {
         if (name.size() > 0 || commands.size() == 0) {
             return name;
         }
@@ -933,7 +936,7 @@ public:
         }
     }
 
-    void set_generic_requirement(QVariant value) {
+    void set_generic_requirement(QVariant value) override {
         selected_path = value.toString().toStdWString();
     }
 
@@ -1325,7 +1328,7 @@ public:
         }
     }
 
-    void pre_perform() {
+    void pre_perform() override {
         if (INCREMENTAL_SEARCH) {
             widget->main_document_view->add_mark('/');
         }
@@ -1337,7 +1340,7 @@ public:
         }
     }
 
-    void perform() {
+    void perform() override {
         // this search is not incremental even if incremental search is activated
         // (for example it should update the search terms list)
         widget->perform_search(this->text.value(), false, false);
@@ -1346,16 +1349,16 @@ public:
         }
     }
 
-    bool pushes_state() {
+    bool pushes_state() override {
         return true;
     }
 
-    std::optional<std::wstring> get_text_suggestion(int index) {
+    std::optional<std::wstring> get_text_suggestion(int index) override {
         return widget->get_search_suggestion_with_index(index);
     }
 
 
-    std::string text_requirement_name() {
+    std::string text_requirement_name() override {
         return "Search Term";
     }
 
@@ -1941,7 +1944,7 @@ public:
 
     AddBookmarkMarkedCommand(MainWidget* w) : Command(cname, w) {};
 
-    std::optional<Requirement> next_requirement(MainWidget* widget) {
+    std::optional<Requirement> next_requirement(MainWidget* widget) override {
 
         if (!point_.has_value()) {
             Requirement req = { RequirementType::Point, "Bookmark Location" };
@@ -1954,12 +1957,12 @@ public:
         return {};
     }
 
-    void set_text_requirement(std::wstring value) {
+    void set_text_requirement(std::wstring value) override {
         text_ = value;
     }
 
 
-    void set_point_requirement(AbsoluteDocumentPos value) {
+    void set_point_requirement(AbsoluteDocumentPos value) override {
         point_ = value;
 
         BookMark incomplete_bookmark;
@@ -1978,7 +1981,7 @@ public:
         }
     }
 
-    void perform() {
+    void perform() override {
         if (text_->size() > 0) {
             std::string uuid = widget->doc()->add_pending_bookmark(pending_index, text_.value());
             widget->invalidate_render();
@@ -2179,7 +2182,7 @@ public:
         widget->doc()->get_bookmarks()[widget->selected_bookmark_index].description = new_text.toStdWString();
     }
 
-    std::optional<Requirement> next_requirement(MainWidget* widget) {
+    std::optional<Requirement> next_requirement(MainWidget* widget) override {
 
         if (!rect_.has_value()) {
             Requirement req = { RequirementType::Rect, "Bookmark Location" };
@@ -2192,11 +2195,11 @@ public:
         return {};
     }
 
-    void set_text_requirement(std::wstring value) {
+    void set_text_requirement(std::wstring value) override {
         text_ = value;
     }
 
-    void set_rect_requirement(AbsoluteRect value) {
+    void set_rect_requirement(AbsoluteRect value) override {
         rect_ = value;
         BookMark incomplete_bookmark;
 
@@ -2216,14 +2219,14 @@ public:
     }
 
 
-    void on_cancel() {
+    void on_cancel() override {
 
         if (pending_index != -1) {
             widget->doc()->undo_pending_bookmark(pending_index);
         }
     }
 
-    void perform() {
+    void perform() override {
         //widget->doc()->add_freetext_bookmark(text_.value(), rect_.value());
         if (text_.value().size() > 0) {
             std::string uuid = widget->doc()->add_pending_bookmark(pending_index, text_.value());
@@ -2654,7 +2657,7 @@ public:
     QTimer* timer = nullptr;
     QMetaObject::Connection timer_connection;
 
-    std::optional<Requirement> next_requirement(MainWidget* widget) {
+    std::optional<Requirement> next_requirement(MainWidget* widget) override {
         if (!finished) {
             return Requirement{ RequirementType::Generic, "dummy" };
         }
@@ -2671,8 +2674,7 @@ public:
         }
     }
 
-    void set_generic_requirement(QVariant value)
-    {
+    void set_generic_requirement(QVariant value) override {
         finished = true;
     }
 
@@ -2692,7 +2694,7 @@ public:
 
     }
 
-    void perform() {
+    void perform() override {
     }
 
 };
@@ -2707,7 +2709,7 @@ public:
         start_time = QDateTime::currentDateTime();
     };
 
-    std::optional<Requirement> next_requirement(MainWidget* widget) {
+    std::optional<Requirement> next_requirement(MainWidget* widget) override {
         if (duration.has_value()) {
             return GenericWaitCommand::next_requirement(widget);
         }
@@ -2717,7 +2719,7 @@ public:
     }
 
 
-    void set_text_requirement(std::wstring text) {
+    void set_text_requirement(std::wstring text) override {
         duration = QString::fromStdWString(text).toInt();
     }
 
@@ -2732,8 +2734,7 @@ public:
     static inline const std::string hname = "";
     WaitForIndexingToFinishCommand(MainWidget* w) : GenericWaitCommand(cname, w) {};
 
-    void set_generic_requirement(QVariant value)
-    {
+    void set_generic_requirement(QVariant value) override {
         finished = true;
     }
 
@@ -3293,7 +3294,7 @@ public:
         widget->doc()->get_bookmarks()[widget->selected_bookmark_index].description = new_text.toStdWString();
     }
 
-    void pre_perform() {
+    void pre_perform() override {
 
         if (widget->selected_bookmark_index > -1) {
             initial_text = widget->doc()->get_bookmarks()[widget->selected_bookmark_index].description;
@@ -3316,19 +3317,19 @@ public:
         }
     }
 
-    void on_cancel() {
+    void on_cancel() override {
         if (index > -1) {
             widget->doc()->get_bookmarks()[index].description = initial_text;
             widget->doc()->get_bookmarks()[index].font_size = initial_font_size;
         }
     }
 
-    std::optional<Requirement> next_requirement(MainWidget* widget) {
+    std::optional<Requirement> next_requirement(MainWidget* widget) override {
         if (widget->selected_bookmark_index == -1) return {};
         return TextCommand::next_requirement(widget);
     }
 
-    void perform() {
+    void perform() override {
         if (widget->selected_bookmark_index != -1) {
             std::wstring text_ = text.value();
             widget->change_selected_bookmark_text(text_);
@@ -3339,7 +3340,7 @@ public:
         }
     }
 
-    std::string text_requirement_name() {
+    std::string text_requirement_name() override {
         return "Bookmark Text";
     }
 
@@ -3428,7 +3429,7 @@ public:
         }
     }
 
-    std::optional<Requirement> next_requirement(MainWidget* widget) {
+    std::optional<Requirement> next_requirement(MainWidget* widget) override {
         // since pre_perform must be executed in order to determine the requirements, we manually run it here
         pre_perform();
 
@@ -3441,13 +3442,13 @@ public:
     }
 
 
-    virtual void set_symbol_requirement(char value) {
+    virtual void set_symbol_requirement(char value) override {
         tag.push_back(value);
     }
 
     virtual void perform_with_selected_index(std::optional<int> index) = 0;
 
-    void perform() {
+    void perform() override {
         bool should_clear_labels = false;
         if (tag.size() > 0) {
             int index = get_index_from_tag(tag);
@@ -3795,7 +3796,7 @@ public:
 
 public:
 
-    void perform() {
+    void perform() override {
 
         std::string mark_str = "";
         if (mark) {
@@ -3820,7 +3821,7 @@ public:
         mark = value;
     }
 
-    virtual std::optional<Requirement> next_requirement(MainWidget* widget) {
+    virtual std::optional<Requirement> next_requirement(MainWidget* widget) override {
         if (mark) return {};
 
         if (widget->get_ruler_portals().size() > 1) {
@@ -4610,17 +4611,17 @@ public:
 
     }
 
-    void perform() {
+    void perform() override {
         widget->handle_keyboard_select(text.value());
         widget->set_highlighted_tags({});
     }
 
-    void pre_perform() {
+    void pre_perform() override {
         widget->highlight_words();
 
     }
 
-    std::string text_requirement_name() {
+    std::string text_requirement_name() override {
         return "Labels";
     }
 };
@@ -7056,7 +7057,7 @@ void get_tokens(std::wstring line, std::vector<std::wstring>& tokens) {
         if (stack_depth && (c != '>') && (c != '<')) {
             stack.push_back(c);
         }
-        else if ((c == '>')) {
+        else if (c == '>') {
             stack_depth--;
             if (stack_depth == 0) {
                 tokens.push_back(stack);

--- a/pdf_viewer/main_widget.cpp
+++ b/pdf_viewer/main_widget.cpp
@@ -1049,12 +1049,12 @@ MainWidget::MainWidget(fz_context* mupdf_context,
                     if (dynamic_cast<FilteredSelectTableWindowClass<std::wstring>*>(current_widget_stack.back())) {
                         FilteredSelectTableWindowClass<std::wstring>* list_view = dynamic_cast<FilteredSelectTableWindowClass<std::wstring>*>(current_widget_stack.back());
                         list_view->set_value_second_item(url.toStdWString(),
-                            file_size_to_human_readable_string(reply->header(QNetworkRequest::ContentLengthHeader).toUInt()));
+                            file_size_to_human_readable_string(reply->header(QNetworkRequest::ContentLengthHeader).toULongLong()));
                     }
                     if (dynamic_cast<TouchFilteredSelectWidget<std::wstring>*>(current_widget_stack.back())) {
                         TouchFilteredSelectWidget<std::wstring>* list_view = dynamic_cast<TouchFilteredSelectWidget<std::wstring>*>(current_widget_stack.back());
                         list_view->set_value_second_item(url.toStdWString(),
-                            file_size_to_human_readable_string(reply->header(QNetworkRequest::ContentLengthHeader).toUInt()));
+                            file_size_to_human_readable_string(reply->header(QNetworkRequest::ContentLengthHeader).toULongLong()));
                     }
                     });
 
@@ -3794,7 +3794,7 @@ void MainWidget::execute_command(std::wstring command, std::wstring text, bool w
 
     QString qtext = QString::fromStdWString(command);
 
-    qtext.arg(qfile_path);
+    qtext = qtext.arg(qfile_path);
 
 #ifdef SIOYEK_QT6
     QStringList command_parts_ = qtext.split(QRegularExpression("\\s+"), Qt::SkipEmptyParts);
@@ -7794,22 +7794,22 @@ void MainWidget::handle_pen_drawing_event(QTabletEvent* te) {
     }
 
     if (te->type() == QEvent::TabletRelease) {
-        finish_drawing(te->pos());
+        finish_drawing(te->position());
         invalidate_render();
     }
 
     if (te->type() == QEvent::TabletMove) {
         if (is_drawing) {
-            handle_drawing_move(te->pos(), te->pressure());
+            handle_drawing_move(te->position(), te->pressure());
             validate_render();
         }
 
     }
 }
 
-void MainWidget::handle_drawing_move(QPoint pos, float pressure) {
+void MainWidget::handle_drawing_move(QPointF pos, float pressure) {
     pressure = 0;
-    WindowPos current_window_pos = { pos.x(), pos.y() };
+    WindowPos current_window_pos = { static_cast<float>(pos.x()), static_cast<float>(pos.y()) };
     AbsoluteDocumentPos mouse_abspos = get_window_abspos(current_window_pos);
     FreehandDrawingPoint fdp;
     fdp.pos = mouse_abspos;
@@ -7835,7 +7835,7 @@ void MainWidget::start_drawing() {
     opengl_widget->current_drawing.alpha = freehand_alpha;
 }
 
-void MainWidget::finish_drawing(QPoint pos) {
+void MainWidget::finish_drawing(QPointF pos) {
     is_drawing = false;
 
     if (opengl_widget->current_drawing.points.size() == 0) {

--- a/pdf_viewer/main_widget.h
+++ b/pdf_viewer/main_widget.h
@@ -718,9 +718,9 @@ public:
     bool is_in_edit_portal_rect(WindowPos pos);
     bool is_in_visual_mark_next_rect(WindowPos pos);
     bool is_in_visual_mark_prev_rect(WindowPos pos);
-    void handle_drawing_move(QPoint pos, float pressure);
+    void handle_drawing_move(QPointF pos, float pressure);
     void start_drawing();
-    void finish_drawing(QPoint pos);
+    void finish_drawing(QPointF pos);
     void handle_pen_drawing_event(QTabletEvent* te);
     void select_freehand_drawings(AbsoluteRect rect);
     void delete_freehand_drawings(AbsoluteRect rect);

--- a/pdf_viewer/pdf_view_opengl_widget.cpp
+++ b/pdf_viewer/pdf_view_opengl_widget.cpp
@@ -2241,6 +2241,7 @@ float PdfViewOpenGLWidget::get_overview_side_pos(int index) {
     if (index == OverviewSide::right) {
         return overview_offset_x + overview_half_width;
     }
+    return 0.0f;
 }
 
 void PdfViewOpenGLWidget::set_overview_side_pos(OverviewSide index, NormalizedWindowRect original_rect, fvec2 diff) {

--- a/pdf_viewer/utf8/checked.h
+++ b/pdf_viewer/utf8/checked.h
@@ -265,7 +265,13 @@ namespace utf8
 
     // The iterator class
     template <typename octet_iterator>
-    class iterator : public std::iterator <std::bidirectional_iterator_tag, uint32_t> {
+    class iterator {
+    public:
+      using iterator_category = std::bidirectional_iterator_tag;
+      using value_type = uint32_t;
+      using difference_type = std::ptrdiff_t;
+      using pointer = uint32_t*;
+      using reference = uint32_t&;
       octet_iterator it;
       octet_iterator range_start;
       octet_iterator range_end;

--- a/pdf_viewer/utf8/unchecked.h
+++ b/pdf_viewer/utf8/unchecked.h
@@ -176,9 +176,14 @@ namespace utf8
 
         // The iterator class
         template <typename octet_iterator>
-          class iterator : public std::iterator <std::bidirectional_iterator_tag, uint32_t> { 
+          class iterator {
             octet_iterator it;
             public:
+            using iterator_category = std::bidirectional_iterator_tag;
+            using value_type = uint32_t;
+            using difference_type = std::ptrdiff_t;
+            using pointer = value_type*;
+            using reference = value_type&;
             iterator () {}
             explicit iterator (const octet_iterator& octet_it): it(octet_it) {}
             // the default "big three" are OK

--- a/pdf_viewer/utils.cpp
+++ b/pdf_viewer/utils.cpp
@@ -556,7 +556,7 @@ bool is_index_reverse_reference_number(const std::vector<fz_stext_char*>& flat_c
     int n_chars = chars_between_last_dot_and_index.size();
     if (n_chars > 0 && n_chars < 20) {
         for (int i = 0; i < n_chars; i++) {
-            if ((chars_between_last_dot_and_index[i] > 0) && (chars_between_last_dot_and_index[i] < 128) && std::isalpha(chars_between_last_dot_and_index[i])) {
+            if ((chars_between_last_dot_and_index[i] > 0) && std::isalpha(chars_between_last_dot_and_index[i])) {
                 return false;
             }
         }
@@ -1383,7 +1383,7 @@ void index_generic(const std::vector<fz_stext_char*>& flat_chars, int page_numbe
         }
     }
 
-    std::wregex index_dst_regex(L"(^|\n)[A-Z][a-zA-Z]{2,}\.?[ \t]+[0-9]+(\.[0-9]+)*");
+    std::wregex index_dst_regex(L"(^|\n)[A-Z][a-zA-Z]{2,}\\.?[ \t]+[0-9]+(\\.?[0-9]+)*");
     //std::wregex index_dst_regex(L"(^|\n)[A-Z][a-zA-Z]{2,}[ \t]+[0-9]+(\-[0-9]+)*");
     //std::wregex index_src_regex(L"[a-zA-Z]{3,}[ \t]+[0-9]+(\.[0-9]+)*");
     std::wsmatch match;
@@ -3525,7 +3525,7 @@ QStringList extract_paper_string_from_json_response(QJsonObject json_object, std
     return extract_paper_data_from_json_response(json_object, parts);
 }
 
-QString file_size_to_human_readable_string(int file_size) {
+QString file_size_to_human_readable_string(long long int file_size) {
     if (file_size < 1000) {
         return QString::number(file_size);
     }
@@ -3535,7 +3535,7 @@ QString file_size_to_human_readable_string(int file_size) {
     else if (file_size < 1000 * 1000 * 1000) {
         return QString::number(file_size / (1000 * 1000)) + "M";
     }
-    else if (file_size < 1000 * 1000 * 1000 * 1000) {
+    else if (file_size < 1000LL * 1000LL * 1000LL * 1000LL) {
         return QString::number(file_size / (1000 * 1000 * 1000)) + "G";
     }
     else {
@@ -3651,7 +3651,7 @@ std::wstring get_paper_name_from_reference_text(std::wstring reference_text) {
 
         QString str = QString::fromStdWString(reference_text);
         //QRegularExpression reference_ending_dot_regex = QRegularExpression("(\.\w*In )|(\.\w*[aA]r[xX]iv )|(\.\w*[aA]r[X]iv )");
-        QRegularExpression reference_ending_dot_regex = QRegularExpression("(\.\w*In )|(\.\w*[aA]r[xX]iv )");
+        QRegularExpression reference_ending_dot_regex = QRegularExpression("(\\.\\w*In )|(\\.\\w*[aA]r[xX]iv )");
 
         int ending_index = str.lastIndexOf(reference_ending_dot_regex);
         if (ending_index == -1) {
@@ -3830,7 +3830,7 @@ bool is_text_refernce_rather_than_paper_name(std::wstring text) {
         return true;
     }
 
-    QStringList parts = QString::fromStdWString(text).split(QRegularExpression("[ \(\)]"));
+    QStringList parts = QString::fromStdWString(text).split(QRegularExpression("[ \\(\\)]"));
     for (int i = 0; i < parts.size(); i++) {
         if (is_year(parts[i])) {
             return true;

--- a/pdf_viewer/utils.h
+++ b/pdf_viewer/utils.h
@@ -258,7 +258,7 @@ bool are_rects_same(fz_rect r1, fz_rect r2);
 
 QStringList extract_paper_data_from_json_response(QJsonValue json_object, const std::vector<QString>& path);
 QStringList extract_paper_string_from_json_response(QJsonObject json_object, std::wstring path);
-QString file_size_to_human_readable_string(int file_size);
+QString file_size_to_human_readable_string(long long int file_size);
 
 std::wstring new_uuid();
 std::string new_uuid_utf8();
@@ -448,6 +448,7 @@ bool should_trigger_delete(QKeyEvent *key_event);
 
 class TextToSpeechHandler {
 public:
+    virtual ~TextToSpeechHandler() = default;
     virtual void set_rate(float rate) = 0;
     virtual void say(QString text) = 0;
     virtual void stop() = 0;


### PR DESCRIPTION
This is my attempt to get sioyek to compile with without errors and warnings from clang.

The changes help fix deprecation warnings while compiling against Qt 6.8, compiler warnings and potential errors. 

We go from around 50+ diagnostics down to 1 so thats good. I currently didn't apply any logical changes so we should be fine. 
Please let me know about the review