### PR TITLE
Document new configs (`add_newlines_when_copying_text` and `custom_color_mode_empty_background_color`)

### DIFF
--- a/pdf_viewer/prefs.config
+++ b/pdf_viewer/prefs.config
@@ -116,6 +116,8 @@ sort_bookmarks_by_location	1
 
 ## Background color to use when executing `toggle_custom_color`
 custom_background_color 0.180 0.204 0.251
+## Color of area outside pdf when executing `toggle_custom_color`
+custom_color_mode_empty_background_color 0 0 0
 ## Text color to use when executing `toggle_custom_color`
 custom_text_color 0.847 0.871 0.914
 

--- a/pdf_viewer/prefs.config
+++ b/pdf_viewer/prefs.config
@@ -189,6 +189,9 @@ should_warn_about_user_key_override 1
 # Use double clicks to select entire words and single clicks for character-based selection
 single_click_selects_words 0
 
+# Preserve newline characters when copying text
+add_newlines_when_copying_text 0
+
 # A prefix to prepend to items in lists (e.g. bookmark lists)
 #item_list_prefix >
 


### PR DESCRIPTION
These are config options you suggested in issues that I had created (#1193 and #1189). They weren't documented in `prefs.config` so I thought I'd add them since they are useful options. 

I have set `custom_color_mode_empty_background_color` to be black by default instead of setting it as same as `custom_background_color`.

I was also thinking of adding these configs to the documentation site but that seems to only have the main branch. I assume that should be in sync with this repo's main branch?