### PR TITLE
Fix typos and improve capitalization

### DIFF
--- a/pdf_viewer/prefs.config
+++ b/pdf_viewer/prefs.config
@@ -6,7 +6,7 @@ check_for_updates_on_startup	0
 # Use old keybind parsing method (only for backwards compatibility)
 use_legacy_keybinds 0
 
-# The color with which the screen is cleared before rendering the pdf (this is the background color of the application and not the PDF file)
+# The color with which the screen is cleared before rendering the PDF (this is the background color of the application and not the PDF file)
 background_color    0.97 0.97 0.97
 dark_mode_background_color    0.0 0.0 0.0
 
@@ -22,20 +22,20 @@ visual_mark_color    0.0 0.0 0.0 0.1
 # Highlight color when text is a search match
 search_highlight_color  0.0 1.0 0.0
 
-# Hihglight color for PDF links (note that highlight is off by default
+# Highlight color for PDF links (note that highlight is off by default
 # and can only be seen by performing a toggle_highlight command. See keys.config for more details)
 link_highlight_color    0.0 0.0 1.0
 
-# Hihglight color for synctex forward search highlights
+# Highlight color for SyncTeX forward search highlights
 synctex_highlight_color    1.0 0.0 1.0
 
-# Urls to use when executing external_search commands
+# URLs to use when executing external_search commands
 search_url_s	https://scholar.google.com/scholar?q=
 search_url_l	http://gen.lib.rus.ec/scimag/?q=
 search_url_g	https://www.google.com/search?q=
 
-# Which search url to choose when middle clicking or shift middle clicking on text (the values are the letters of corresponding search_url_* )
-# for example if i set `middle_click_search_engine	s`, then we use the url associated with `search_url_s` to handle middle click searches
+# Which search URL to choose when middle clicking or shift middle clicking on text (the values are the letters of corresponding search_url_* )
+# for example if i set `middle_click_search_engine	s`, then we use the URL associated with `search_url_s` to handle middle click searches
 middle_click_search_engine			s
 shift_middle_click_search_engine	l
 
@@ -50,13 +50,13 @@ horizontal_move_amount    1.0
 # Here we specify the fraction of the screen width by which we move when performing these commands
 move_screen_ratio      0.5
 
-# If 0, Table of Contents is shown in a hierarchial tree, otherwise it is a flat list (can improve performance for extremely large table of contents)
+# If 0, Table of Contents is shown in a hierarchical tree, otherwise it is a flat list (can improve performance for extremely large table of contents)
 flat_toc                            0
 
 # If it is 1, when launching the application if we detect multiple monitors, we automatically launch the helper window in second monitor
 should_use_multiple_monitors        0
 
-# If the last opened document is empty, load the tutorial pdf instead
+# If the last opened document is empty, load the tutorial PDF instead
 should_load_tutorial_when_no_other_file	1
 
 # (deprecated, use `should_launch_new_window` instead) If it is 0, then we use the previous instance of sioyek when launching a new file.
@@ -67,12 +67,12 @@ should_launch_new_instance				0
 should_launch_new_window				0
 
 # The command to use when trying to do inverse search into a LaTeX document. Uncomment and provide your own command.
-# %1 expands to the name of the file and %2 expans to the line number.
+# %1 expands to the name of the file and %2 expands to the line number.
 #inverse_search_command 		"C:\path\to\vscode\Code.exe" -r -g %1:%2
 
 # you can specify the exact highlight color for each of 26 different highlight types
 
-# When moving to the next line using visual marker, this setting specifies the distance of the market to the top of the screen in fractions of screen size (center of the screen is zero, top of the screen is one)
+# When moving to the next line using visual marker, this setting specifies the distance of the marker to the top of the screen in fractions of screen size (center of the screen is zero, top of the screen is one)
 visual_mark_next_page_fraction	0.75
 
 # When moving to the next line using visual marker, this setting determines at which point we move the screen (center of the screen is zero, bottom of the screen is one)
@@ -89,8 +89,8 @@ rerender_overview 1
 ## Size of the overview window (1 being as large as the window, valid range is [0, 1])
 # overview_size 0.5 0.5
 
-## Offset of the center of the overview window ((0,0) being the center of the screen and valid raneg is [-1, 1])
-# overview_offset 0.5 0.5
+## Offset of the center of the overview window ((0,0) being the center of the screen and valid range is [-1, 1])
+overview_offset 0.5 0.5
 
 # Use linear texture filtering instead of nearest-neighbor
 # Can improve appearance in very high-resolution screens 
@@ -140,8 +140,8 @@ wheel_zoom_on_cursor 0
 #helper_window_size 800 600
 #helper_window_move 100 100
 
-## Touchpad/scrollwhell sensitivity
-#touchpad_sensitivity 1.0
+## Touchpad/scrollwheel sensitivity
+touchpad_sensitivity 1.0
 
 ## Configure the appearance of page separator
 #page_separator_width 2
@@ -161,8 +161,8 @@ ruler_mode 1
 ruler_padding 1.0
 ruler_x_padding 5.0
 
-## We use mupdf to determine lines for visual mark. However, we do have a custom algorithm for image documents
-## if `force_custom_line_algorithm` is 1, then we use our custom algorithm instead of mupdf even for documents 
+## We use MuPDF to determine lines for visual mark. However, we do have a custom algorithm for image documents
+## if `force_custom_line_algorithm` is 1, then we use our custom algorithm instead of MuPDF even for documents 
 ## that have lines.
 #force_custom_line_algorithm 0
 
@@ -217,8 +217,8 @@ prerender_next_page_presentation 1
 # Highlight on middle clicks when text is selected and no preview is open
 #highlight_middle_click 1
 
-# Use a super fast index for search instead of the mupdf's implementation
-#super_fast_search 1
+# Use a super fast index for search instead of MuPDF's implementation
+super_fast_search 1
 
 # Use case-insensitive search
 #case_sensitive_search 0
@@ -275,4 +275,3 @@ highlight_color_x	1.00 1.00 0.50
 highlight_color_y	1.00 1.00 0.00
 #Zinnia
 highlight_color_z	1.00 0.31 0.02
-


### PR DESCRIPTION
This PR fixes various typos and inconsistencies in the [prefs.config](https://github.com/ahrm/sioyek/blob/main/pdf_viewer/prefs.config) file to improve readability and maintain consistent terminology throughout the configuration file.

### Fixed spelling errors
- Changed "hierarchial" to "hierarchical"
- Changed "market" to "marker"
- Changed "raneg" to "range"
- Changed "scrollwhell" to "scrollwheel"
- Changed "expans" to "expands"

### Fixed capitalization of proper names and acronyms
- Changed "pdf" to "PDF" for consistency
- Changed "mupdf" to "MuPDF"
- Changed "Urls/url" to "URLs/URL"
- Changed "synctex" to "SyncTeX"

### Fixed grammar
- Removed unnecessary "the" before "MuPDF's"