### PR TITLE
Add simulate_move_left and simulate_move_right

### DIFF
--- a/pdf_viewer/main_widget.cpp
+++ b/pdf_viewer/main_widget.cpp
@@ -9561,6 +9561,12 @@ QString MainWidget::handle_action_in_menu(std::wstring action) {
         if (action == L"up") {
             selector_widget->simulate_move_up();
         }
+        if (action == L"left") {
+            selector_widget->simulate_move_left();
+        }
+        if (action == L"right") {
+            selector_widget->simulate_move_right();
+        }
         if (action == L"page_down") {
             selector_widget->simulate_page_down();
         }

--- a/pdf_viewer/ui.cpp
+++ b/pdf_viewer/ui.cpp
@@ -1707,6 +1707,16 @@ void BaseSelectorWidget::simulate_move_up() {
     QCoreApplication::postEvent(get_view(), move_up_event);
 }
 
+void BaseSelectorWidget::simulate_move_left() {
+    QKeyEvent* move_left_event = new QKeyEvent(QEvent::Type::KeyPress, Qt::Key_Left, Qt::KeyboardModifier::NoModifier);
+    QCoreApplication::postEvent(get_view(), move_left_event);
+}
+
+void BaseSelectorWidget::simulate_move_right() {
+    QKeyEvent* move_right_event = new QKeyEvent(QEvent::Type::KeyPress, Qt::Key_Right, Qt::KeyboardModifier::NoModifier);
+    QCoreApplication::postEvent(get_view(), move_right_event);
+}
+
 QString BaseSelectorWidget::get_selected_item() {
     if (get_selected_index()) {
         return get_view()->model()->data(get_selected_index().value()).toString();

--- a/pdf_viewer/ui.h
+++ b/pdf_viewer/ui.h
@@ -152,6 +152,8 @@ public:
     bool eventFilter(QObject* obj, QEvent* event) override;
     void simulate_move_down();
     void simulate_move_up();
+    void simulate_move_left();
+    void simulate_move_right();
     void simulate_page_down();
     void simulate_page_up();
     void simulate_end();


### PR DESCRIPTION
This PR adds `simulate_move_left` and `simulate_move_right` so that one can for example configure `[m]control_menu(left) <C-h>` as a keybinding.
I think that this should take care of #1002.

PS: Thanks for this awesome program! :)