### PR TITLE
Resolve build failure due to "too many arguments" error in network_manager.get call

### DIFF
--- a/pdf_viewer/main_widget.cpp
+++ b/pdf_viewer/main_widget.cpp
@@ -11492,7 +11492,7 @@ QString MainWidget::perform_network_request_with_headers(QString method, QString
             reply = network_manager.post(req, QJsonDocument(request).toJson());
         }
         else {
-            reply = network_manager.get(req, QJsonDocument(request).toJson());
+            reply = network_manager.get(req);
         }
 
         QObject::connect(reply, &QNetworkReply::readyRead, [reply, is_done, response]() {


### PR DESCRIPTION
Hi, this PR addresses a build failure in the `development` branch caused by an incorrect `network_manager.get` function call within `pdf_viewer/main_widget.cpp`. The development branch builds successfully on macOS 15.3.1 after the change.