### PR TITLE
Use default_open_file_path for open_document_embedded

### DIFF
--- a/pdf_viewer/ui.cpp
+++ b/pdf_viewer/ui.cpp
@@ -15,7 +15,6 @@
 #include "touchui/TouchConfigMenu.h"
 #include "touchui/TouchSettings.h"
 
-extern std::wstring DEFAULT_OPEN_FILE_PATH;
 extern float DARK_MODE_CONTRAST;
 extern float BACKGROUND_COLOR[3];
 extern bool RULER_MODE;
@@ -643,7 +642,7 @@ HighlightButtons::HighlightButtons(MainWidget* parent) : QWidget(parent) {
     //layout = new QHBoxLayout();
 
     //delete_highlight_button = new QPushButton("Delete");
-    //buttons_widget = new 
+    //buttons_widget = new
     highlight_buttons = new TouchHighlightButtons(main_widget->get_current_selected_highlight_type(), this);
 
     QObject::connect(highlight_buttons, &TouchHighlightButtons::deletePressed, [&]() {

--- a/pdf_viewer/ui.h
+++ b/pdf_viewer/ui.h
@@ -73,6 +73,7 @@ extern "C" {
 }
 
 class MainWidget;
+extern std::wstring DEFAULT_OPEN_FILE_PATH;
 extern std::wstring UI_FONT_FACE_NAME;
 extern int FONT_SIZE;
 const int max_select_size = 100;
@@ -626,7 +627,11 @@ public:
         QString root_path;
         QString file_name;
 
-        if (last_path.size() > 0) {
+        if(last_path.size() == 0){
+            root_path = QString::fromStdWString(DEFAULT_OPEN_FILE_PATH);
+            file_name = "";
+        }
+        else if (last_path.size() > 0) {
             split_root_file(last_path, root_path, file_name);
             root_path += QDir::separator();
         }


### PR DESCRIPTION
The `open_document_embedded` does not use the `default_open_file_path` config item.
This change tries to implement that by using the `default_open_file_path` when the embedded fileviewer `last_path` is empty. 