### PR TITLE
Feature recto verso adjustment for two page mode

### DIFF
--- a/pdf_viewer/document.cpp
+++ b/pdf_viewer/document.cpp
@@ -641,6 +641,14 @@ Document::Document(fz_context* context, std::wstring file_name, DatabaseManager*
     should_render_annotations = SHOULD_RENDER_PDF_ANNOTATIONS;
 }
 
+bool Document::get_recto_verso_adjustment() {
+    return recto_verso_adjustment;
+}
+
+void Document::toggle_recto_verso_adjustment() {
+    recto_verso_adjustment = !recto_verso_adjustment ;
+}
+
 void Document::count_chapter_pages(std::vector<int>& page_counts) {
     int num_chapters = fz_count_chapters(context, doc);
 

--- a/pdf_viewer/document.h
+++ b/pdf_viewer/document.h
@@ -147,6 +147,7 @@ private:
     bool are_highlights_loaded = false;
     bool should_render_annotations = true;
     bool should_reload_annotations = false;
+    bool recto_verso_adjustment = false;
 
     QDateTime last_update_time;
     CachedChecksummer* checksummer;
@@ -168,6 +169,7 @@ private:
     void clear_toc_nodes();
     void clear_toc_node(TocNode* node);
     int find_highlight_index_with_uuid(const std::string& uuid);
+
 public:
     fz_document* doc = nullptr;
     std::wstring detected_paper_name = L"";
@@ -197,6 +199,8 @@ public:
     bool should_render_pdf_annotations();
     void set_should_render_pdf_annotations(bool val);
     bool get_should_render_pdf_annotations();
+    bool get_recto_verso_adjustment();
+    void toggle_recto_verso_adjustment();
     std::vector<Portal> get_intersecting_visible_portals(float absrange_begin, float absrange_end);
     CachedPageIndex& get_page_index(int page);
     void fill_search_result(SearchResult* result);

--- a/pdf_viewer/document_view.cpp
+++ b/pdf_viewer/document_view.cpp
@@ -155,6 +155,11 @@ bool DocumentView::set_offsets(float new_offset_x, float new_offset_y, bool forc
     return truncated;
 }
 
+void DocumentView::toggle_recto_verso_adjustment () {
+    current_document->toggle_recto_verso_adjustment();
+    this->fit_to_page_width();
+ }
+
 Document* DocumentView::get_document() {
     return current_document;
 }
@@ -2079,7 +2084,7 @@ void DocumentView::fill_cached_virtual_rects(bool force) {
                 page_rect.y1 = cum_offset + page_height;
 
                 float mult = 1.0f;
-                if (i % 2 == 1) {
+                if ((i + current_document->get_recto_verso_adjustment()) % 2 == 1) {
                     cum_offset += page_height + page_space_y;
                 }
                 else {

--- a/pdf_viewer/document_view.h
+++ b/pdf_viewer/document_view.h
@@ -98,6 +98,7 @@ public:
     Document* get_document();
     bool is_ruler_mode();
     void exit_ruler_mode();
+    void toggle_recto_verso_adjustment();
 
     // find the closest portal to the current position
     // if limit is true, we only search for portals near the current location and not all portals

--- a/pdf_viewer/input.cpp
+++ b/pdf_viewer/input.cpp
@@ -1366,6 +1366,17 @@ public:
     }
 };
 
+class ToggleRectoVersoAdjustment : public Command {
+public:
+    static inline const std::string cname = "toggle_recto_verso_adjustment";
+    static inline const std::string hname = "Toggle recto verso adjustment";
+
+    ToggleRectoVersoAdjustment(MainWidget* w) : Command(cname, w) {};
+    void perform() {
+        widget->main_document_view->toggle_recto_verso_adjustment();
+    }
+};
+
 class SearchCommand : public TextCommand {
 public:
     static inline const std::string cname = "search";
@@ -6964,6 +6975,7 @@ CommandManager::CommandManager(ConfigManager* config_manager) {
     register_command<MoveSelectedBookmarkCommand>();
     register_command<RepeatLastCommandCommnad>();
     register_command<CloseWindowCommand>("q");
+    register_command<ToggleRectoVersoAdjustment>();
 
 
     for (auto [command_name_, command_value] : ADDITIONAL_COMMANDS) {

--- a/pdf_viewer/input.cpp
+++ b/pdf_viewer/input.cpp
@@ -989,12 +989,12 @@ public:
 
 };
 
-class GenericPathAndLocationCommadn : public Command {
+class GenericPathAndLocationCommand : public Command {
 public:
 
     std::optional<QVariant> target_location;
     bool is_hash = false;
-    GenericPathAndLocationCommadn(std::string name, MainWidget* w, bool is_hash_ = false) : Command(name, w) { is_hash = is_hash_; };
+    GenericPathAndLocationCommand(std::string name, MainWidget* w, bool is_hash_ = false) : Command(name, w) { is_hash = is_hash_; };
 
     std::optional<Requirement> next_requirement(MainWidget* widget) {
         if (target_location) {
@@ -2316,12 +2316,12 @@ public:
     }
 };
 
-class GotoBookmarkGlobalCommand : public GenericPathAndLocationCommadn {
+class GotoBookmarkGlobalCommand : public GenericPathAndLocationCommand {
 public:
     static inline const std::string cname = "goto_bookmark_g";
     static inline const std::string hname = "Open the bookmark list of all documents";
 
-    GotoBookmarkGlobalCommand(MainWidget* w) : GenericPathAndLocationCommadn(cname, w) {};
+    GotoBookmarkGlobalCommand(MainWidget* w) : GenericPathAndLocationCommand(cname, w) {};
 
     void handle_generic_requirement() {
         widget->handle_goto_bookmark_global();
@@ -2373,12 +2373,12 @@ public:
 };
 
 
-class GotoHighlightGlobalCommand : public GenericPathAndLocationCommadn {
+class GotoHighlightGlobalCommand : public GenericPathAndLocationCommand {
 public:
     static inline const std::string cname = "goto_highlight_g";
     static inline const std::string hname = "Open the highlight list of the all documents";
 
-    GotoHighlightGlobalCommand(MainWidget* w) : GenericPathAndLocationCommadn(cname, w) {};
+    GotoHighlightGlobalCommand(MainWidget* w) : GenericPathAndLocationCommand(cname, w) {};
 
     void handle_generic_requirement() {
         widget->handle_goto_highlight_global();
@@ -3694,11 +3694,11 @@ public:
     }
 };
 
-class OpenPrevDocCommand : public GenericPathAndLocationCommadn {
+class OpenPrevDocCommand : public GenericPathAndLocationCommand {
 public:
     static inline const std::string cname = "open_prev_doc";
     static inline const std::string hname = "Open the list of previously opened documents";
-    OpenPrevDocCommand(MainWidget* w) : GenericPathAndLocationCommadn(cname, w, true) {};
+    OpenPrevDocCommand(MainWidget* w) : GenericPathAndLocationCommand(cname, w, true) {};
 
     void handle_generic_requirement() {
         widget->handle_open_prev_doc();
@@ -3707,11 +3707,11 @@ public:
     bool requires_document() { return false; }
 };
 
-class OpenAllDocsCommand : public GenericPathAndLocationCommadn {
+class OpenAllDocsCommand : public GenericPathAndLocationCommand {
 public:
     static inline const std::string cname = "open_all_docs";
     static inline const std::string hname = "";
-    OpenAllDocsCommand(MainWidget* w) : GenericPathAndLocationCommadn(cname, w, true) {};
+    OpenAllDocsCommand(MainWidget* w) : GenericPathAndLocationCommand(cname, w, true) {};
 
     void handle_generic_requirement() {
         widget->handle_open_all_docs();

--- a/pdf_viewer/main_widget.cpp
+++ b/pdf_viewer/main_widget.cpp
@@ -2919,7 +2919,7 @@ void MainWidget::mouseReleaseEvent(QMouseEvent* mevent) {
             execute_macro_if_enabled(CONTROL_CLICK_COMMAND);
         }
         else if (is_command_pressed) {
-            //todo: replace with command click commadn
+            //todo: replace with command click command
             execute_macro_if_enabled(CONTROL_CLICK_COMMAND);
         }
         else if (is_alt_pressed) {

--- a/pdf_viewer/main_widget.cpp
+++ b/pdf_viewer/main_widget.cpp
@@ -3859,6 +3859,11 @@ CommandManager* MainWidget::get_command_manager() {
     return command_manager;
 }
 
+void MainWidget::toggle_recto_verso_adjustment() {
+    this->main_document_view->toggle_recto_verso_adjustment();
+    return;
+}
+
 void MainWidget::toggle_dark_mode() {
     this->opengl_widget->toggle_dark_mode();
 
@@ -11145,6 +11150,7 @@ QMenuBar* MainWidget::create_main_menu_bar(){
             new MenuNode{ "-", "", {} },
             new MenuNode{ "toggle_two_page_mode", "", {} },
             new MenuNode{ "toggle_dark_mode", "", {} },
+            new MenuNode{ "toggle_recto_verso_adjustment", "", {} },
             new MenuNode{ "toggle_custom_color", "", {} },
             new MenuNode{ "toggle_scrollbar", "", {} },
             new MenuNode{ "toggle_statusbar", "", {} },

--- a/pdf_viewer/main_widget.h
+++ b/pdf_viewer/main_widget.h
@@ -552,6 +552,7 @@ public:
     void handle_drawing_ui_visibilty();
 
     void toggle_dark_mode();
+    void toggle_recto_verso_adjustment();
     void toggle_custom_color_mode();
     void do_synctex_forward_search(const Path& pdf_file_path, const Path& latex_file_path, int line, int column);
     //void handle_args(const QStringList &arguments);

--- a/scripts/tools/command_names.txt
+++ b/scripts/tools/command_names.txt
@@ -466,6 +466,7 @@ synctex_under_ruler
 test_command
 toggle_custom_color
 toggle_dark_mode
+toggle_recto_verso_adjustment
 toggle_drawing_mask
 toggle_fastread
 toggle_freehand_drawing_mode


### PR DESCRIPTION
Documents with missing pages, especially title pages and covers, can end up with the pages flipped so that recto pages are incorrectly displayed on the left and vice versa. This PR adds an offset and associated command to toggle the offset so documents can be correctly displayed.

PR also fixes some typos I found along the way. Let me know what you think.