### PR TITLE
Feature - trailing slashes for directories in embedded viewer

### DIFF
--- a/pdf_viewer/input.cpp
+++ b/pdf_viewer/input.cpp
@@ -1025,12 +1025,12 @@ public:
 
 };
 
-class GenericPathAndLocationCommadn : public Command {
+class GenericPathAndLocationCommand : public Command {
 public:
 
     std::optional<QVariant> target_location;
     bool is_hash = false;
-    GenericPathAndLocationCommadn(std::string name, MainWidget* w, bool is_hash_ = false) : Command(name, w) { is_hash = is_hash_; };
+    GenericPathAndLocationCommand(std::string name, MainWidget* w, bool is_hash_ = false) : Command(name, w) { is_hash = is_hash_; };
 
     std::optional<Requirement> next_requirement(MainWidget* widget) {
         if (target_location) {
@@ -2352,12 +2352,12 @@ public:
     }
 };
 
-class GotoBookmarkGlobalCommand : public GenericPathAndLocationCommadn {
+class GotoBookmarkGlobalCommand : public GenericPathAndLocationCommand {
 public:
     static inline const std::string cname = "goto_bookmark_g";
     static inline const std::string hname = "Open the bookmark list of all documents";
 
-    GotoBookmarkGlobalCommand(MainWidget* w) : GenericPathAndLocationCommadn(cname, w) {};
+    GotoBookmarkGlobalCommand(MainWidget* w) : GenericPathAndLocationCommand(cname, w) {};
 
     void handle_generic_requirement() {
         widget->handle_goto_bookmark_global();
@@ -2409,12 +2409,12 @@ public:
 };
 
 
-class GotoHighlightGlobalCommand : public GenericPathAndLocationCommadn {
+class GotoHighlightGlobalCommand : public GenericPathAndLocationCommand {
 public:
     static inline const std::string cname = "goto_highlight_g";
     static inline const std::string hname = "Open the highlight list of the all documents";
 
-    GotoHighlightGlobalCommand(MainWidget* w) : GenericPathAndLocationCommadn(cname, w) {};
+    GotoHighlightGlobalCommand(MainWidget* w) : GenericPathAndLocationCommand(cname, w) {};
 
     void handle_generic_requirement() {
         widget->handle_goto_highlight_global();
@@ -3730,11 +3730,11 @@ public:
     }
 };
 
-class OpenPrevDocCommand : public GenericPathAndLocationCommadn {
+class OpenPrevDocCommand : public GenericPathAndLocationCommand {
 public:
     static inline const std::string cname = "open_prev_doc";
     static inline const std::string hname = "Open the list of previously opened documents";
-    OpenPrevDocCommand(MainWidget* w) : GenericPathAndLocationCommadn(cname, w, true) {};
+    OpenPrevDocCommand(MainWidget* w) : GenericPathAndLocationCommand(cname, w, true) {};
 
     void handle_generic_requirement() {
         widget->handle_open_prev_doc();
@@ -3743,11 +3743,11 @@ public:
     bool requires_document() { return false; }
 };
 
-class OpenAllDocsCommand : public GenericPathAndLocationCommadn {
+class OpenAllDocsCommand : public GenericPathAndLocationCommand {
 public:
     static inline const std::string cname = "open_all_docs";
     static inline const std::string hname = "";
-    OpenAllDocsCommand(MainWidget* w) : GenericPathAndLocationCommadn(cname, w, true) {};
+    OpenAllDocsCommand(MainWidget* w) : GenericPathAndLocationCommand(cname, w, true) {};
 
     void handle_generic_requirement() {
         widget->handle_open_all_docs();

--- a/pdf_viewer/main_widget.cpp
+++ b/pdf_viewer/main_widget.cpp
@@ -2921,7 +2921,7 @@ void MainWidget::mouseReleaseEvent(QMouseEvent* mevent) {
             execute_macro_if_enabled(CONTROL_CLICK_COMMAND);
         }
         else if (is_command_pressed) {
-            //todo: replace with command click commadn
+            //todo: replace with command click command
             execute_macro_if_enabled(CONTROL_CLICK_COMMAND);
         }
         else if (is_alt_pressed) {


### PR DESCRIPTION
Thought the suggestion in #1384 was a good idea. I added a filter to take the current dir out of the list too since it takes up space and doesn't do anything. Similarly the readable filter takes out anything you don't have permission to view. Using the canonical path instead of "full_path" avoids things like "../../foo/../bar/baz" if you look around before choosing a file which can get annoying and hard to read.

Other commit is just non-functional typo corrections.