### PR TITLE
Fix issues from #1419

### DIFF
--- a/pdf_viewer/document_view.cpp
+++ b/pdf_viewer/document_view.cpp
@@ -732,8 +732,10 @@ void DocumentView::move_pages(int num_pages) {
     if (current_page == -1) {
         current_page = 0;
     }
-
-    move_virtual(0, num_pages * (current_document->get_page_height(current_page) + PAGE_PADDINGS));
+    auto page_view_height = current_document->get_page_height(current_page) + PAGE_PADDINGS;
+    if (two_page_mode)
+        page_view_height += get_page_space_y();
+    move_virtual(0, num_pages * page_view_height);
 }
 
 void DocumentView::move_screens(int num_screens) {

--- a/pdf_viewer/document_view.cpp
+++ b/pdf_viewer/document_view.cpp
@@ -2199,7 +2199,7 @@ float DocumentView::get_page_space_x() {
 }
 
 float DocumentView::get_page_space_y() {
-    return page_space_x;
+    return page_space_y;
 }
 
 bool DocumentView::fast_coordinates() {

--- a/pdf_viewer/document_view.cpp
+++ b/pdf_viewer/document_view.cpp
@@ -990,13 +990,19 @@ void DocumentView::fit_to_page_height_width_minimum(int statusbar_height) {
     int page_width = current_document->get_page_width(cp);
     int page_height = current_document->get_page_height(cp);
 
+    if (two_page_mode) {
+        page_space_x = PAGE_SPACE_X;
+        cached_virtual_rects.clear();
+        offset.x = 0;
+        page_width += page_width + page_space_x;
+    }
+
     float x_zoom_level = static_cast<float>(view_width) / page_width;
-    float y_zoom_level;
-    y_zoom_level = (static_cast<float>(view_height) - statusbar_height) / page_height;
+    float y_zoom_level =
+        (static_cast<float>(view_height) - statusbar_height) / page_height;
 
-    set_offset_x(0);
+
     set_zoom_level(std::min(x_zoom_level, y_zoom_level), true);
-
 }
 
 void DocumentView::persist(bool persist_drawings) {

--- a/pdf_viewer/main_widget.cpp
+++ b/pdf_viewer/main_widget.cpp
@@ -2051,6 +2051,7 @@ void MainWidget::open_document(const Path& path, std::optional<float> offset_x, 
     }
 
     deselect_document_indices();
+    main_document_view->fit_to_page_height_width_minimum(0);
     invalidate_render();
 
 }


### PR DESCRIPTION
Fixes the issues with scrolling up/down a page (the borders in two page mode weren't included in the calculation) and the weird bug in two page mode where documents open off to one side.

Open to input / comments as always.