### PR TITLE
bugfix - fixes utf8 exception in detect_paper_name

### DIFF
--- a/pdf_viewer/document.cpp
+++ b/pdf_viewer/document.cpp
@@ -4304,7 +4304,13 @@ std::wstring Document::detect_paper_name(fz_context* context, fz_document* doc) 
         else {
             char buffer[1000];
             fz_lookup_metadata(context, doc, FZ_META_INFO_TITLE, buffer, 1000);
-            return utf8_decode(buffer);
+            try {
+                return utf8_decode(buffer);
+            }
+            catch (utf8::exception& e) {
+                std::cerr << "error detecting paper name: " << e.what()
+                          << " ...leaving name blank" << std::endl;
+            }
         }
     }
     return L"";


### PR DESCRIPTION
Fixes #1411 
`utf8_decode` called from `detect_paper_name` can throw, in particular when given invalid utf8. Adds a try / catch block in the calling function to account for this possibility. Behaviour is that invalid utf8 causes the paper name to be left blank and an error message is logged to stderr.