### PR TITLE
Fix writing data path to $XDG_CONFIG_HOME instead of $XDG_DATA_HOME

### DIFF
--- a/pdf_viewer/main.cpp
+++ b/pdf_viewer/main.cpp
@@ -248,15 +248,18 @@ void configure_paths() {
     last_opened_file_address_path = standard_data_path.slash(L"last_document_path.txt");
     shader_path = read_only_data_path.slash(L"shaders");
 #else
-    char* APPDIR = std::getenv("XDG_CONFIG_HOME");
+    char* APPDIR = std::getenv("XDG_DATA_HOME");
     Path linux_home_path(QDir::homePath().toStdWString());
 
     if (!APPDIR) {
         APPDIR = std::getenv("HOME");
+        standard_data_path = Path(utf8_decode(APPDIR));
+        standard_data_path = standard_data_path.slash(L".local").slash(L"share");
+    } else {
+        standard_data_path = Path(utf8_decode(APPDIR));
     }
 
-    standard_data_path = Path(utf8_decode(APPDIR));
-    standard_data_path = standard_data_path.slash(L".local").slash(L"share").slash(L"Sioyek");
+    standard_data_path = standard_data_path.slash(L"sioyek");
     standard_data_path.create_directories();
 
     default_config_path = parent_path.slash(L"prefs.config");


### PR DESCRIPTION
Fixes #1523

Now writes to $XDG_DATA_HOME/sioyek instead of $XDG_CONFIG_HOME/.local/share/Sioyek if set. Otherwise, writes to $HOME/.local/share/sioyek