### PR TITLE
Fix a bug where changes to highlights' types do not persist

### DIFF
--- a/build_linux.sh
+++ b/build_linux.sh
@@ -12,6 +12,9 @@ then
     if [ -f "/usr/bin/qmake-qt6" ]; 
     then
         QMAKE="/usr/bin/qmake-qt6"
+    elif [ -f "/usr/bin/qmake6" ]; 
+    then
+        QMAKE="/usr/bin/qmake6"
     elif [ -f "/usr/bin/qmake" ]; 
     then
         QMAKE="/usr/bin/qmake"

--- a/pdf_viewer/database.cpp
+++ b/pdf_viewer/database.cpp
@@ -1881,7 +1881,7 @@ std::wstring encode_variant(QVariant var) {
 
 
     std::vector<QString> specials = { "CURRENT_TIMESTAMP", "datetime('now')" };
-    if ((var.typeId() == QMetaType::QString) || (var.typeId() == QMetaType::Char)) {
+    if ((var.typeId() == QMetaType::QString) || (var.typeId() == QMetaType::QChar)) {
         if (std::find(specials.begin(), specials.end(), var.toString()) != specials.end()) {
             return var.toString().toStdWString();
         }


### PR DESCRIPTION
**Steps to reproduce:** Select an existing highlight, then press `h` followed by a letter, then quit Sioyek. When Sioyek is re-opened, the change is forgotten.

This is a regression, introduced in ed14e38. The storage type `QVariant::Char` corresponds to `QMetaType::QChar`, rather than `QMetaType::Char`. This behaviour is documented [here](https://doc.qt.io/qt-6/qvariant-obsolete.html#type).

I have also tweaked the Linux build script. On my system the appropriate symlink is `qmake6` (`qmake-qt6` does not exist).