### PR TITLE
Makes icon visible in hotbar/panel on linux

### DIFF
--- a/resources/sioyek.desktop
+++ b/resources/sioyek.desktop
@@ -10,3 +10,4 @@ Type=Application
 Icon=sioyek-icon-linux
 Categories=Development;Viewer;
 MimeType=application/pdf;
+StartupWMClass=sioyek


### PR DESCRIPTION
Currently atleast on Linux Mint the icon for Sioyek is absent and is replaced with a generic icon instead. This line I have added to the .desktop file should make it work and I have got it to work on my machine.