### PR TITLE
Fix presentation mode search and highlight visibility

### DIFF
--- a/pdf_viewer/document_view.cpp
+++ b/pdf_viewer/document_view.cpp
@@ -714,6 +714,14 @@ int DocumentView::get_center_page_number() {
 void DocumentView::get_visible_pages(int window_height, std::vector<int>& visible_pages) {
     if (!current_document) return;
 
+    if (is_presentation_mode()) {
+        int presentation_page = presentation_page_number.value();
+        if ((presentation_page >= 0) && (presentation_page < current_document->num_pages())) {
+            visible_pages.push_back(presentation_page);
+        }
+        return;
+    }
+
     AbsoluteDocumentPos abs_offset = virtual_to_absolute_pos(offset);
     float window_y_range_begin = abs_offset.y - window_height / (1.5 * zoom_level);
     float window_y_range_end = abs_offset.y + window_height / (1.5 * zoom_level);
@@ -1944,6 +1952,33 @@ std::vector<int> DocumentView::get_visible_highlight_indices() {
     const std::vector<Highlight>& highlights = get_document()->get_highlights();
 
     std::vector<int> res;
+
+    if (is_presentation_mode()) {
+        int presentation_page = presentation_page_number.value();
+
+        for (size_t i = 0; i < highlights.size(); i++) {
+            bool is_visible = false;
+
+            for (const auto& rect : highlights[i].highlight_rects) {
+                if (get_document()->absolute_to_page_rect(rect).page == presentation_page) {
+                    is_visible = true;
+                    break;
+                }
+            }
+
+            if ((!is_visible) && (highlights[i].highlight_rects.size() == 0)) {
+                int begin_page = get_document()->get_offset_page_number(highlights[i].selection_begin.y);
+                int end_page = get_document()->get_offset_page_number(highlights[i].selection_end.y);
+                is_visible = (begin_page == presentation_page) || (end_page == presentation_page);
+            }
+
+            if (is_visible) {
+                res.push_back(i);
+            }
+        }
+
+        return res;
+    }
 
     for (size_t i = 0; i < highlights.size(); i++) {
 

--- a/pdf_viewer/pdf_view_opengl_widget.cpp
+++ b/pdf_viewer/pdf_view_opengl_widget.cpp
@@ -1530,8 +1530,11 @@ void PdfViewOpenGLWidget::my_render(QPainter* painter) {
         std::array<float, 3> search_highlight_color = cc3(DEFAULT_SEARCH_HIGHLIGHT_COLOR);
         glUniform3fv(shared_gl_objects.highlight_color_uniform_location, 1, &search_highlight_color[0]);
         glUniform1f(shared_gl_objects.highlight_opacity_uniform_location, 0.3f);
-        for (auto rect : current_search_result.rects) {
-            render_highlight_document(shared_gl_objects.highlight_program, DocumentRect { rect, current_search_result.page });
+        bool current_search_result_is_visible = std::find(visible_pages.begin(), visible_pages.end(), current_search_result.page) != visible_pages.end();
+        if (current_search_result_is_visible) {
+            for (auto rect : current_search_result.rects) {
+                render_highlight_document(shared_gl_objects.highlight_program, DocumentRect { rect, current_search_result.page });
+            }
         }
     }
     search_results_mutex.unlock();


### PR DESCRIPTION
## Summary
- limit presentation mode overlays to the active page
- prevent search matches and saved highlights from drawing on adjacent pages
- keep selected search result rendering consistent with presentation mode visibility
## Testing
- built locally on macOS
- verified search highlights no longer appear above or below the active page in presentation mode
- verified saved highlights also stay on the active page
- verified overlays move correctly when changing presentation pages
## Original Issue Before / After
**Before entering presentation mode**
<img width="1079" height="1885" alt="f8f8ddba631e6e36288e112d379a06fbf3e5d4e41d8468392fe88bf15b66cb63" src="https://github.com/user-attachments/assets/79dd0868-9c44-4184-8980-dc8a6e3668cb" />

**After entering presentation mode**

<img width="1080" height="1868" alt="e8e9d53eb839e935f897a60fda93bfc2474b2644c88b528f1bce4db167e87f1f" src="https://github.com/user-attachments/assets/687d847e-18ca-4640-a77e-26a0483a8c56">




