### PR TITLE
Feature/add supernote mark support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ qt_add_executable(sioyek WIN32 MACOSX_BUNDLE
     pdf_viewer/database.cpp pdf_viewer/database.h
     pdf_viewer/document.cpp pdf_viewer/document.h
     pdf_viewer/document_view.cpp pdf_viewer/document_view.h
+    pdf_viewer/mark_parser.cpp pdf_viewer/mark_parser.h
     pdf_viewer/fts_fuzzy_match.h
     pdf_viewer/input.cpp pdf_viewer/input.h
     pdf_viewer/main.cpp

--- a/pdf_viewer/document.cpp
+++ b/pdf_viewer/document.cpp
@@ -3639,53 +3639,6 @@ void Document::load_drawings() {
 
 }
 
-void Document::load_png_overlays() {
-    if (png_overlays_loaded) {
-        return;
-    }
-
-    png_overlays_loaded = true;
-    page_png_overlays.clear();
-
-    // Get the PDF path and look for foo.pdf_0.png, foo.pdf_1.png, etc.
-    QString pdf_path = QString::fromStdWString(file_name);
-
-    // Try to load PNG overlays for each page
-    int n_pages = num_pages();
-    for (int page = 0; page < n_pages; page++) {
-        QString png_path = pdf_path + "_" + QString::number(page) + ".png";
-
-        if (QFile::exists(png_path)) {
-            QPixmap pixmap(png_path);
-            if (!pixmap.isNull()) {
-                page_png_overlays[page] = pixmap;
-            }
-        }
-    }
-
-    if (page_png_overlays.size() > 0) {
-        std::cerr << "[sioyek] Loaded " << page_png_overlays.size() << " PNG overlays for " << pdf_path.toStdString() << std::endl;
-    }
-}
-
-bool Document::has_png_overlay(int page) {
-    if (!png_overlays_loaded) {
-        load_png_overlays();
-    }
-    return page_png_overlays.find(page) != page_png_overlays.end();
-}
-
-QPixmap* Document::get_png_overlay(int page) {
-    if (!png_overlays_loaded) {
-        load_png_overlays();
-    }
-    auto it = page_png_overlays.find(page);
-    if (it != page_png_overlays.end()) {
-        return &it->second;
-    }
-    return nullptr;
-}
-
 void Document::load_mark_file() {
     if (mark_file_loaded) {
         return;
@@ -3710,44 +3663,58 @@ void Document::load_mark_file() {
     }
 }
 
-bool Document::has_mark_overlay(int page) {
+const QPixmap* Document::get_supernote_overlay(int page) {
+    // Try .mark file first
     if (!mark_file_loaded) {
         load_mark_file();
     }
-    if (!mark_parser) {
-        return false;
+    if (mark_parser) {
+        QPixmap pixmap = mark_parser->get_page_pixmap(page);
+        if (!pixmap.isNull()) {
+            // Cache it so we can return a stable pointer
+            auto result = page_png_overlays.emplace(page, std::move(pixmap));
+            return &result.first->second;
+        }
     }
-    return mark_parser->has_page(page);
+
+    // Then try PNG overlay (lazy per-page loading)
+    if (png_pages_checked_.find(page) == png_pages_checked_.end()) {
+        png_pages_checked_.insert(page);
+        QString pdf_path = QString::fromStdWString(file_name);
+        QString png_path = pdf_path + "_" + QString::number(page) + ".png";
+        if (QFile::exists(png_path)) {
+            QPixmap pixmap(png_path);
+            if (!pixmap.isNull()) {
+                page_png_overlays[page] = std::move(pixmap);
+            }
+        }
+    }
+
+    auto it = page_png_overlays.find(page);
+    if (it != page_png_overlays.end()) {
+        return &it->second;
+    }
+    return nullptr;
 }
 
-QPixmap Document::get_mark_overlay(int page) {
-    if (!mark_file_loaded) {
-        load_mark_file();
+const QPixmap* Document::get_supernote_overlay_inverted(int page) {
+    // Check inverted cache first
+    auto it = inverted_overlay_cache.find(page);
+    if (it != inverted_overlay_cache.end()) {
+        return &it->second;
     }
-    if (!mark_parser) {
-        return QPixmap();
-    }
-    return mark_parser->get_page_pixmap(page);
-}
 
-bool Document::has_supernote_overlay(int page) {
-    // Try .mark file first, then PNG overlays
-    if (has_mark_overlay(page)) {
-        return true;
+    // Get the normal overlay
+    const QPixmap* overlay = get_supernote_overlay(page);
+    if (!overlay) {
+        return nullptr;
     }
-    return has_png_overlay(page);
-}
 
-QPixmap Document::get_supernote_overlay(int page) {
-    // Try .mark file first, then PNG overlays
-    if (has_mark_overlay(page)) {
-        return get_mark_overlay(page);
-    }
-    QPixmap* png = get_png_overlay(page);
-    if (png) {
-        return *png;
-    }
-    return QPixmap();
+    // Create and cache the inverted version
+    QImage img = overlay->toImage();
+    img.invertPixels(QImage::InvertRgb);  // Invert RGB, preserve alpha
+    inverted_overlay_cache[page] = QPixmap::fromImage(img);
+    return &inverted_overlay_cache[page];
 }
 
 void Document::persist_annotations(bool force) {

--- a/pdf_viewer/document.cpp
+++ b/pdf_viewer/document.cpp
@@ -3639,6 +3639,117 @@ void Document::load_drawings() {
 
 }
 
+void Document::load_png_overlays() {
+    if (png_overlays_loaded) {
+        return;
+    }
+
+    png_overlays_loaded = true;
+    page_png_overlays.clear();
+
+    // Get the PDF path and look for foo.pdf_0.png, foo.pdf_1.png, etc.
+    QString pdf_path = QString::fromStdWString(file_name);
+
+    // Try to load PNG overlays for each page
+    int n_pages = num_pages();
+    for (int page = 0; page < n_pages; page++) {
+        QString png_path = pdf_path + "_" + QString::number(page) + ".png";
+
+        if (QFile::exists(png_path)) {
+            QPixmap pixmap(png_path);
+            if (!pixmap.isNull()) {
+                page_png_overlays[page] = pixmap;
+            }
+        }
+    }
+
+    if (page_png_overlays.size() > 0) {
+        std::cerr << "[sioyek] Loaded " << page_png_overlays.size() << " PNG overlays for " << pdf_path.toStdString() << std::endl;
+    }
+}
+
+bool Document::has_png_overlay(int page) {
+    if (!png_overlays_loaded) {
+        load_png_overlays();
+    }
+    return page_png_overlays.find(page) != page_png_overlays.end();
+}
+
+QPixmap* Document::get_png_overlay(int page) {
+    if (!png_overlays_loaded) {
+        load_png_overlays();
+    }
+    auto it = page_png_overlays.find(page);
+    if (it != page_png_overlays.end()) {
+        return &it->second;
+    }
+    return nullptr;
+}
+
+void Document::load_mark_file() {
+    if (mark_file_loaded) {
+        return;
+    }
+
+    mark_file_loaded = true;
+
+    // Look for foo.pdf.mark file
+    QString pdf_path = QString::fromStdWString(file_name);
+    QString mark_path = pdf_path + ".mark";
+
+    if (!QFile::exists(mark_path)) {
+        return;
+    }
+
+    mark_parser = std::make_unique<MarkFileParser>();
+    if (mark_parser->load(mark_path)) {
+        std::cerr << "[sioyek] Loaded .mark file: " << mark_path.toStdString() << std::endl;
+    } else {
+        mark_parser.reset();
+        std::cerr << "[sioyek] Failed to load .mark file: " << mark_path.toStdString() << std::endl;
+    }
+}
+
+bool Document::has_mark_overlay(int page) {
+    if (!mark_file_loaded) {
+        load_mark_file();
+    }
+    if (!mark_parser) {
+        return false;
+    }
+    return mark_parser->has_page(page);
+}
+
+QPixmap Document::get_mark_overlay(int page) {
+    if (!mark_file_loaded) {
+        load_mark_file();
+    }
+    if (!mark_parser) {
+        return QPixmap();
+    }
+    return mark_parser->get_page_pixmap(page);
+}
+
+bool Document::has_supernote_overlay(int page) {
+    // Try .mark file first, then PNG overlays
+    if (has_mark_overlay(page)) {
+        return true;
+    }
+    return has_png_overlay(page);
+}
+
+QPixmap Document::get_supernote_overlay(int page) {
+    // Try .mark file first, then PNG overlays
+    if (has_mark_overlay(page)) {
+        return get_mark_overlay(page);
+    }
+    QPixmap* png = get_png_overlay(page);
+    if (png) {
+        return *png;
+    }
+    return QPixmap();
+}
+
 void Document::persist_annotations(bool force) {
 
     if ((!is_annotations_dirty) && (!force)) {

--- a/pdf_viewer/document.h
+++ b/pdf_viewer/document.h
@@ -6,6 +6,7 @@
 #include <thread>
 #include <mutex>
 #include <map>
+#include <set>
 #include <unordered_map>
 #include <deque>
 #include <regex>
@@ -75,7 +76,10 @@ private:
 
     // PNG overlays for Supernote-style annotations (foo.pdf_0.png, foo.pdf_1.png, etc.)
     std::map<int, QPixmap> page_png_overlays;
-    bool png_overlays_loaded = false;
+    std::set<int> png_pages_checked_;
+
+    // Cached inverted overlays for dark/custom color modes
+    std::map<int, QPixmap> inverted_overlay_cache;
 
     // .mark file parser for direct Supernote annotation support
     std::unique_ptr<MarkFileParser> mark_parser;
@@ -434,19 +438,14 @@ public:
     AbsoluteRect to_absolute(int page, fz_quad quad);
     AbsoluteRect to_absolute(int page, PagelessDocumentRect rect);
 
-    // PNG overlay support for Supernote-style annotations
-    void load_png_overlays();
-    bool has_png_overlay(int page);
-    QPixmap* get_png_overlay(int page);
-
     // .mark file support for direct Supernote annotation loading
     void load_mark_file();
-    bool has_mark_overlay(int page);
-    QPixmap get_mark_overlay(int page);
 
     // Combined overlay support (tries .mark first, then PNG)
-    bool has_supernote_overlay(int page);
-    QPixmap get_supernote_overlay(int page);
+    // Returns nullptr if no overlay exists for this page
+    const QPixmap* get_supernote_overlay(int page);
+    // Returns the inverted version for dark/custom color modes (cached)
+    const QPixmap* get_supernote_overlay_inverted(int page);
 
     bool get_should_reload_annotations();
     void reload_annotations_on_new_checksum();

--- a/pdf_viewer/document.h
+++ b/pdf_viewer/document.h
@@ -9,6 +9,7 @@
 #include <unordered_map>
 #include <deque>
 #include <regex>
+#include <memory>
 
 //#include <Windows.h>
 #include <qstandarditemmodel.h>
@@ -22,6 +23,7 @@
 
 #include "book.h"
 #include "coordinates.h"
+#include "mark_parser.h"
 
 class CachedChecksummer;
 class DatabaseManager;
@@ -70,6 +72,14 @@ private:
     // which means that when we exit, we must write the modified drawings to the drawings file
     bool is_drawings_dirty = false;
     bool is_annotations_dirty = false;
+
+    // PNG overlays for Supernote-style annotations (foo.pdf_0.png, foo.pdf_1.png, etc.)
+    std::map<int, QPixmap> page_png_overlays;
+    bool png_overlays_loaded = false;
+
+    // .mark file parser for direct Supernote annotation support
+    std::unique_ptr<MarkFileParser> mark_parser;
+    bool mark_file_loaded = false;
 
     std::vector<Mark> marks;
     std::vector<BookMark> bookmarks;
@@ -423,6 +433,20 @@ public:
     const std::vector<FreehandDrawing>& get_page_drawings(int page);
     AbsoluteRect to_absolute(int page, fz_quad quad);
     AbsoluteRect to_absolute(int page, PagelessDocumentRect rect);
+
+    // PNG overlay support for Supernote-style annotations
+    void load_png_overlays();
+    bool has_png_overlay(int page);
+    QPixmap* get_png_overlay(int page);
+
+    // .mark file support for direct Supernote annotation loading
+    void load_mark_file();
+    bool has_mark_overlay(int page);
+    QPixmap get_mark_overlay(int page);
+
+    // Combined overlay support (tries .mark first, then PNG)
+    bool has_supernote_overlay(int page);
+    QPixmap get_supernote_overlay(int page);
 
     bool get_should_reload_annotations();
     void reload_annotations_on_new_checksum();

--- a/pdf_viewer/mark_parser.cpp
+++ b/pdf_viewer/mark_parser.cpp
@@ -78,6 +78,7 @@ QMap<QString, QVariant> MarkFileParser::parse_metadata_block(QFile& file, uint32
 bool MarkFileParser::load(const QString& mark_file_path) {
     file_path_ = mark_file_path;
     file_data_ = MarkFileData();
+    page_set_.clear();
     cached_pixmaps_.clear();
 
     QFile file(mark_file_path);
@@ -162,11 +163,11 @@ bool MarkFileParser::load(const QString& mark_file_path) {
 
         // Get main layer address
         if (page_meta.contains("MAINLAYER")) {
-            page_info.main_layer_address = page_meta["MAINLAYER"].toString().toUInt();
+            uint32_t main_layer_address = page_meta["MAINLAYER"].toString().toUInt();
 
-            if (page_info.main_layer_address > 0) {
+            if (main_layer_address > 0) {
                 // Parse layer metadata
-                QMap<QString, QVariant> layer_meta = parse_metadata_block(file, page_info.main_layer_address);
+                QMap<QString, QVariant> layer_meta = parse_metadata_block(file, main_layer_address);
 
                 MarkLayerInfo layer;
                 layer.name = "MAINLAYER";
@@ -210,6 +211,7 @@ bool MarkFileParser::load(const QString& mark_file_path) {
             }
         }
 
+        page_set_.insert(page_num);
         file_data_.pages.push_back(page_info);
     }
 
@@ -374,15 +376,6 @@ int MarkFileParser::page_count() const {
     return static_cast<int>(file_data_.pages.size());
 }
 
-bool MarkFileParser::has_page(int page) const {
-    for (const auto& p : file_data_.pages) {
-        if (p.page_number == page) {
-            return true;
-        }
-    }
-    return false;
-}
-
 QPixmap MarkFileParser::get_page_pixmap(int page) {
     // Check cache first
     auto it = cached_pixmaps_.find(page);
@@ -390,7 +383,12 @@ QPixmap MarkFileParser::get_page_pixmap(int page) {
         return it->second;
     }
 
-    // Find the page
+    // Check if page exists using the set for O(log n) lookup
+    if (page_set_.find(page) == page_set_.end()) {
+        return QPixmap();
+    }
+
+    // Find the page info
     const MarkPageInfo* page_info = nullptr;
     for (const auto& p : file_data_.pages) {
         if (p.page_number == page) {

--- a/pdf_viewer/mark_parser.cpp
+++ b/pdf_viewer/mark_parser.cpp
@@ -1,0 +1,458 @@
+#include "mark_parser.h"
+#include <cstring>
+#include <iostream>
+#include <qpainter.h>
+#include <qregularexpression.h>
+
+MarkFileParser::MarkFileParser() {}
+
+MarkFileParser::~MarkFileParser() {}
+
+uint32_t MarkFileParser::read_uint32_le(QFile& file) {
+    uint8_t bytes[4];
+    if (file.read(reinterpret_cast<char*>(bytes), 4) != 4) {
+        return 0;
+    }
+    return bytes[0] | (bytes[1] << 8) | (bytes[2] << 16) | (bytes[3] << 24);
+}
+
+QByteArray MarkFileParser::read_data_at_address(QFile& file, uint32_t address) {
+    if (address == 0) {
+        return QByteArray();
+    }
+
+    if (!file.seek(address)) {
+        return QByteArray();
+    }
+
+    uint32_t length = read_uint32_le(file);
+    if (length == 0 || length > 100000000) {  // Sanity check
+        return QByteArray();
+    }
+
+    return file.read(length);
+}
+
+QMap<QString, QVariant> MarkFileParser::parse_key_value_pairs(const QByteArray& data) {
+    QMap<QString, QVariant> result;
+    QString str = QString::fromUtf8(data);
+
+    // Parse <KEY:VALUE> pairs using regex
+    QRegularExpression regex("<([^:<>]+):([^:<>]*)>");
+    QRegularExpressionMatchIterator it = regex.globalMatch(str);
+
+    while (it.hasNext()) {
+        QRegularExpressionMatch match = it.next();
+        QString key = match.captured(1);
+        QString value = match.captured(2);
+
+        // Handle duplicate keys by storing as list
+        if (result.contains(key)) {
+            QVariant existing = result[key];
+            if (existing.type() == QVariant::StringList) {
+                QStringList list = existing.toStringList();
+                list.append(value);
+                result[key] = list;
+            } else {
+                QStringList list;
+                list.append(existing.toString());
+                list.append(value);
+                result[key] = list;
+            }
+        } else {
+            result[key] = value;
+        }
+    }
+
+    return result;
+}
+
+QMap<QString, QVariant> MarkFileParser::parse_metadata_block(QFile& file, uint32_t address) {
+    QByteArray data = read_data_at_address(file, address);
+    if (data.isEmpty()) {
+        return QMap<QString, QVariant>();
+    }
+    return parse_key_value_pairs(data);
+}
+
+bool MarkFileParser::load(const QString& mark_file_path) {
+    file_path_ = mark_file_path;
+    file_data_ = MarkFileData();
+    cached_pixmaps_.clear();
+
+    QFile file(mark_file_path);
+    if (!file.open(QIODevice::ReadOnly)) {
+        std::cerr << "[sioyek] MarkFileParser: failed to open " << mark_file_path.toStdString() << std::endl;
+        return false;
+    }
+
+    // Check file type (first 4 bytes) - can be "mark" or "MARK"
+    QByteArray file_type = file.read(4);
+    if (file_type.toLower() != "mark") {
+        std::cerr << "[sioyek] MarkFileParser: not a MARK file (got: " << file_type.toStdString() << ")" << std::endl;
+        return false;
+    }
+    file_data_.file_type = QString::fromLatin1(file_type).toUpper();
+
+    // Read footer address from last 4 bytes
+    file.seek(file.size() - 4);
+    uint32_t footer_address = read_uint32_le(file);
+
+    if (footer_address == 0 || footer_address >= file.size()) {
+        std::cerr << "[sioyek] MarkFileParser: invalid footer address" << std::endl;
+        return false;
+    }
+
+    // Parse footer block
+    QMap<QString, QVariant> footer = parse_metadata_block(file, footer_address);
+    if (footer.isEmpty()) {
+        std::cerr << "[sioyek] MarkFileParser: failed to parse footer" << std::endl;
+        return false;
+    }
+
+    // Parse header block (FILE_FEATURE points to it)
+    if (footer.contains("FILE_FEATURE")) {
+        uint32_t header_address = footer["FILE_FEATURE"].toString().toUInt();
+        QMap<QString, QVariant> header = parse_metadata_block(file, header_address);
+
+        if (header.contains("APPLY_EQUIPMENT")) {
+            file_data_.device_model = header["APPLY_EQUIPMENT"].toString();
+            // Check for X2 device with different resolution
+            if (file_data_.device_model.contains("X2") || file_data_.device_model == "N5") {
+                file_data_.width = 1920;
+                file_data_.height = 2560;
+            }
+        }
+    }
+
+    // Parse pages (PAGE1, PAGE2, etc.)
+    // Note: Pages may be non-sequential (e.g., PAGE1, PAGE3 without PAGE2)
+    // because .mark files only store pages that have annotations.
+    // We iterate through all keys in footer that start with "PAGE".
+    for (auto it = footer.constBegin(); it != footer.constEnd(); ++it) {
+        QString key = it.key();
+        if (!key.startsWith("PAGE")) {
+            continue;
+        }
+
+        // Extract page number from key (e.g., "PAGE3" -> 3)
+        bool ok;
+        int page_num_1indexed = key.mid(4).toInt(&ok);
+        if (!ok || page_num_1indexed < 1) {
+            continue;
+        }
+        int page_num = page_num_1indexed - 1;  // Convert to 0-indexed
+
+        uint32_t page_address = it.value().toString().toUInt();
+        if (page_address == 0) {
+            continue;
+        }
+
+        QMap<QString, QVariant> page_meta = parse_metadata_block(file, page_address);
+        if (page_meta.isEmpty()) {
+            continue;
+        }
+
+        MarkPageInfo page_info;
+        page_info.page_number = page_num;
+
+        if (page_meta.contains("ORIENTATION")) {
+            page_info.orientation = page_meta["ORIENTATION"].toString();
+        }
+
+        // Get main layer address
+        if (page_meta.contains("MAINLAYER")) {
+            page_info.main_layer_address = page_meta["MAINLAYER"].toString().toUInt();
+
+            if (page_info.main_layer_address > 0) {
+                // Parse layer metadata
+                QMap<QString, QVariant> layer_meta = parse_metadata_block(file, page_info.main_layer_address);
+
+                MarkLayerInfo layer;
+                layer.name = "MAINLAYER";
+                if (layer_meta.contains("LAYERPROTOCOL")) {
+                    layer.protocol = layer_meta["LAYERPROTOCOL"].toString();
+                }
+                if (layer_meta.contains("LAYERBITMAP")) {
+                    layer.bitmap_address = layer_meta["LAYERBITMAP"].toString().toUInt();
+                }
+                if (layer_meta.contains("LAYERTYPE")) {
+                    layer.type = layer_meta["LAYERTYPE"].toString();
+                }
+                layer.is_visible = true;
+                page_info.layers.push_back(layer);
+            }
+        }
+
+        // Also check other layers (LAYER1, LAYER2, LAYER3, BGLAYER)
+        QStringList layer_keys = {"LAYER1", "LAYER2", "LAYER3", "BGLAYER"};
+        for (const QString& layer_key : layer_keys) {
+            if (page_meta.contains(layer_key)) {
+                uint32_t layer_address = page_meta[layer_key].toString().toUInt();
+                if (layer_address > 0) {
+                    QMap<QString, QVariant> layer_meta = parse_metadata_block(file, layer_address);
+
+                    MarkLayerInfo layer;
+                    layer.name = layer_key;
+                    if (layer_meta.contains("LAYERPROTOCOL")) {
+                        layer.protocol = layer_meta["LAYERPROTOCOL"].toString();
+                    }
+                    if (layer_meta.contains("LAYERBITMAP")) {
+                        layer.bitmap_address = layer_meta["LAYERBITMAP"].toString().toUInt();
+                    }
+                    if (layer_meta.contains("LAYERTYPE")) {
+                        layer.type = layer_meta["LAYERTYPE"].toString();
+                    }
+                    // Background layers are typically not for annotations
+                    layer.is_visible = (layer_key != "BGLAYER");
+                    page_info.layers.push_back(layer);
+                }
+            }
+        }
+
+        file_data_.pages.push_back(page_info);
+    }
+
+    file_data_.is_valid = true;
+    std::cerr << "[sioyek] MarkFileParser: loaded " << file_data_.pages.size()
+              << " pages from " << mark_file_path.toStdString() << std::endl;
+
+    return true;
+}
+
+uint32_t MarkFileParser::color_code_to_rgb(uint8_t color_code, bool is_x2_device) {
+    switch (color_code) {
+        case MarkColorCodes::BLACK:
+        case MarkColorCodes::MARKER_BLACK:
+            return MarkPalette::BLACK;
+
+        case MarkColorCodes::BACKGROUND:
+            return MarkPalette::TRANSPARENT;
+
+        case MarkColorCodes::DARK_GRAY:
+        case MarkColorCodes::MARKER_DARK_GRAY:
+            return MarkPalette::DARK_GRAY;
+
+        case MarkColorCodes::DARK_GRAY_X2:
+        case MarkColorCodes::MARKER_DARK_GRAY_X2:
+            return MarkPalette::DARK_GRAY;
+
+        case MarkColorCodes::GRAY:
+        case MarkColorCodes::MARKER_GRAY:
+            return MarkPalette::GRAY;
+
+        case MarkColorCodes::GRAY_X2:
+        case MarkColorCodes::MARKER_GRAY_X2:
+            return MarkPalette::GRAY;
+
+        case MarkColorCodes::WHITE:
+            return MarkPalette::WHITE;
+
+        default:
+            return MarkPalette::TRANSPARENT;
+    }
+}
+
+QByteArray MarkFileParser::decode_rle(const QByteArray& compressed_data, int expected_size, bool is_x2_device) {
+    QByteArray result;
+    result.reserve(expected_size);
+
+    int pos = 0;
+    int data_len = compressed_data.size();
+
+    // State for handling high-bit continuation
+    bool has_holder = false;
+    uint8_t holder_color = 0;
+    uint8_t holder_length = 0;
+
+    while (pos + 1 < data_len && result.size() < expected_size) {
+        uint8_t color_code = static_cast<uint8_t>(compressed_data[pos]);
+        uint8_t length_byte = static_cast<uint8_t>(compressed_data[pos + 1]);
+        pos += 2;
+
+        int run_length = 0;
+
+        if (has_holder) {
+            if (color_code == holder_color) {
+                // Combine with holder
+                run_length = 1 + length_byte + (((holder_length & 0x7f) + 1) << 7);
+            } else {
+                // Output holder first, then process current
+                int holder_run = ((holder_length & 0x7f) + 1) << 7;
+                uint32_t rgb = color_code_to_rgb(holder_color, is_x2_device);
+
+                for (int i = 0; i < holder_run && result.size() < expected_size; i++) {
+                    result.append(static_cast<char>((rgb >> 16) & 0xff));  // R
+                    result.append(static_cast<char>((rgb >> 8) & 0xff));   // G
+                    result.append(static_cast<char>(rgb & 0xff));          // B
+                    result.append(static_cast<char>(rgb == MarkPalette::TRANSPARENT ? 0x00 : 0xff));  // A
+                }
+
+                // Now process current pair
+                if (length_byte == MarkColorCodes::SPECIAL_LENGTH_MARKER) {
+                    run_length = MarkColorCodes::SPECIAL_LENGTH;
+                } else if (length_byte & 0x80) {
+                    // New holder
+                    holder_color = color_code;
+                    holder_length = length_byte;
+                    has_holder = true;
+                    continue;
+                } else {
+                    run_length = length_byte + 1;
+                }
+            }
+            has_holder = false;
+        } else {
+            if (length_byte == MarkColorCodes::SPECIAL_LENGTH_MARKER) {
+                run_length = MarkColorCodes::SPECIAL_LENGTH;
+            } else if (length_byte & 0x80) {
+                // Set holder for next iteration
+                holder_color = color_code;
+                holder_length = length_byte;
+                has_holder = true;
+                continue;
+            } else {
+                run_length = length_byte + 1;
+            }
+        }
+
+        // Output the run
+        uint32_t rgb = color_code_to_rgb(color_code, is_x2_device);
+        uint8_t alpha = (rgb == MarkPalette::TRANSPARENT) ? 0x00 : 0xff;
+
+        for (int i = 0; i < run_length && result.size() < expected_size; i++) {
+            result.append(static_cast<char>((rgb >> 16) & 0xff));  // R
+            result.append(static_cast<char>((rgb >> 8) & 0xff));   // G
+            result.append(static_cast<char>(rgb & 0xff));          // B
+            result.append(static_cast<char>(alpha));               // A
+        }
+    }
+
+    // Handle remaining holder
+    if (has_holder && result.size() < expected_size) {
+        int remaining = (expected_size - result.size()) / 4;
+        uint32_t rgb = color_code_to_rgb(holder_color, is_x2_device);
+        uint8_t alpha = (rgb == MarkPalette::TRANSPARENT) ? 0x00 : 0xff;
+
+        for (int i = 0; i < remaining; i++) {
+            result.append(static_cast<char>((rgb >> 16) & 0xff));
+            result.append(static_cast<char>((rgb >> 8) & 0xff));
+            result.append(static_cast<char>(rgb & 0xff));
+            result.append(static_cast<char>(alpha));
+        }
+    }
+
+    // Pad with transparent pixels if needed
+    while (result.size() < expected_size) {
+        result.append('\xff');  // R
+        result.append('\xff');  // G
+        result.append('\xff');  // B
+        result.append('\x00');  // A (transparent)
+    }
+
+    return result;
+}
+
+QImage MarkFileParser::bitmap_to_image(const QByteArray& bitmap_data, int width, int height) {
+    if (bitmap_data.size() < width * height * 4) {
+        std::cerr << "[sioyek] MarkFileParser: bitmap data too small" << std::endl;
+        return QImage();
+    }
+
+    QImage image(width, height, QImage::Format_RGBA8888);
+
+    const uchar* src = reinterpret_cast<const uchar*>(bitmap_data.constData());
+    for (int y = 0; y < height; y++) {
+        uchar* dest = image.scanLine(y);
+        memcpy(dest, src + y * width * 4, width * 4);
+    }
+
+    return image;
+}
+
+int MarkFileParser::page_count() const {
+    return static_cast<int>(file_data_.pages.size());
+}
+
+bool MarkFileParser::has_page(int page) const {
+    for (const auto& p : file_data_.pages) {
+        if (p.page_number == page) {
+            return true;
+        }
+    }
+    return false;
+}
+
+QPixmap MarkFileParser::get_page_pixmap(int page) {
+    // Check cache first
+    auto it = cached_pixmaps_.find(page);
+    if (it != cached_pixmaps_.end()) {
+        return it->second;
+    }
+
+    // Find the page
+    const MarkPageInfo* page_info = nullptr;
+    for (const auto& p : file_data_.pages) {
+        if (p.page_number == page) {
+            page_info = &p;
+            break;
+        }
+    }
+
+    if (!page_info) {
+        return QPixmap();
+    }
+
+    // Open file for reading bitmap data
+    QFile file(file_path_);
+    if (!file.open(QIODevice::ReadOnly)) {
+        return QPixmap();
+    }
+
+    bool is_x2 = file_data_.device_model.contains("X2") || file_data_.device_model == "N5";
+    int width = file_data_.width;
+    int height = file_data_.height;
+
+    // Handle orientation
+    if (page_info->orientation == "1090") {
+        std::swap(width, height);
+    }
+
+    int expected_size = width * height * 4;  // RGBA
+
+    // Decode layers and composite them
+    QImage final_image(width, height, QImage::Format_RGBA8888);
+    final_image.fill(Qt::transparent);
+
+    for (const auto& layer : page_info->layers) {
+        if (!layer.is_visible || layer.bitmap_address == 0) {
+            continue;
+        }
+
+        QByteArray compressed = read_data_at_address(file, layer.bitmap_address);
+        if (compressed.isEmpty()) {
+            continue;
+        }
+
+        QByteArray decoded = decode_rle(compressed, expected_size, is_x2);
+        if (decoded.isEmpty()) {
+            continue;
+        }
+
+        QImage layer_image = bitmap_to_image(decoded, width, height);
+        if (layer_image.isNull()) {
+            continue;
+        }
+
+        // Composite layer onto final image
+        QPainter painter(&final_image);
+        painter.setCompositionMode(QPainter::CompositionMode_SourceOver);
+        painter.drawImage(0, 0, layer_image);
+        painter.end();
+    }
+
+    QPixmap pixmap = QPixmap::fromImage(final_image);
+    cached_pixmaps_[page] = pixmap;
+
+    return pixmap;
+}

--- a/pdf_viewer/mark_parser.h
+++ b/pdf_viewer/mark_parser.h
@@ -1,0 +1,118 @@
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <vector>
+#include <qfile.h>
+#include <qimage.h>
+#include <qmap.h>
+#include <qpixmap.h>
+#include <qstring.h>
+
+// Color codes used in Supernote RLE encoding
+namespace MarkColorCodes {
+    constexpr uint8_t BLACK = 0x61;
+    constexpr uint8_t BACKGROUND = 0x62;
+    constexpr uint8_t DARK_GRAY = 0x63;
+    constexpr uint8_t GRAY = 0x64;
+    constexpr uint8_t WHITE = 0x65;
+    constexpr uint8_t MARKER_BLACK = 0x66;
+    constexpr uint8_t MARKER_DARK_GRAY = 0x67;
+    constexpr uint8_t MARKER_GRAY = 0x68;
+
+    // X2 device color codes
+    constexpr uint8_t DARK_GRAY_X2 = 0x9D;
+    constexpr uint8_t GRAY_X2 = 0xC9;
+    constexpr uint8_t MARKER_DARK_GRAY_X2 = 0x9E;
+    constexpr uint8_t MARKER_GRAY_X2 = 0xCA;
+
+    // Special markers
+    constexpr uint8_t SPECIAL_LENGTH_MARKER = 0xff;
+    constexpr int SPECIAL_LENGTH = 0x4000;
+    constexpr int SPECIAL_LENGTH_FOR_BLANK = 0x400;
+}
+
+// RGB color palette values
+namespace MarkPalette {
+    constexpr uint32_t BLACK = 0x000000;
+    constexpr uint32_t DARK_GRAY = 0x9d9d9d;
+    constexpr uint32_t GRAY = 0xc9c9c9;
+    constexpr uint32_t WHITE = 0xfefefe;
+    constexpr uint32_t TRANSPARENT = 0xffffff;
+}
+
+// Metadata for a layer within a page
+struct MarkLayerInfo {
+    QString name;
+    QString type;
+    QString protocol;
+    uint32_t bitmap_address = 0;
+    bool is_visible = true;
+};
+
+// Metadata for a page
+struct MarkPageInfo {
+    int page_number = 0;
+    QString orientation;  // "1000" = portrait, "1090" = horizontal
+    std::vector<MarkLayerInfo> layers;
+    uint32_t main_layer_address = 0;
+};
+
+// Parsed .mark file
+struct MarkFileData {
+    QString file_type;
+    QString device_model;
+    int width = 1404;
+    int height = 1872;
+    std::vector<MarkPageInfo> pages;
+    bool is_valid = false;
+};
+
+class MarkFileParser {
+public:
+    MarkFileParser();
+    ~MarkFileParser();
+
+    // Load and parse a .mark file
+    bool load(const QString& mark_file_path);
+
+    // Get the number of pages with annotations
+    int page_count() const;
+
+    // Check if a specific page has annotations
+    bool has_page(int page) const;
+
+    // Get the decoded bitmap as a QPixmap for a specific page
+    // Returns null pixmap if page doesn't exist or decoding fails
+    QPixmap get_page_pixmap(int page);
+
+    // Get page dimensions
+    int get_width() const { return file_data_.width; }
+    int get_height() const { return file_data_.height; }
+
+private:
+    // Parse metadata block at given address
+    QMap<QString, QVariant> parse_metadata_block(QFile& file, uint32_t address);
+
+    // Parse key-value pairs from metadata string
+    QMap<QString, QVariant> parse_key_value_pairs(const QByteArray& data);
+
+    // Read a 4-byte little-endian integer from file
+    uint32_t read_uint32_le(QFile& file);
+
+    // Read binary data from address
+    QByteArray read_data_at_address(QFile& file, uint32_t address);
+
+    // Decode RLE-compressed bitmap data
+    QByteArray decode_rle(const QByteArray& compressed_data, int expected_size, bool is_x2_device = false);
+
+    // Convert decoded bitmap to QImage with transparency
+    QImage bitmap_to_image(const QByteArray& bitmap_data, int width, int height);
+
+    // Map color code to RGB value
+    uint32_t color_code_to_rgb(uint8_t color_code, bool is_x2_device = false);
+
+    QString file_path_;
+    MarkFileData file_data_;
+    std::map<int, QPixmap> cached_pixmaps_;
+};

--- a/pdf_viewer/mark_parser.h
+++ b/pdf_viewer/mark_parser.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <map>
+#include <set>
 #include <vector>
 #include <qfile.h>
 #include <qimage.h>
@@ -55,7 +56,6 @@ struct MarkPageInfo {
     int page_number = 0;
     QString orientation;  // "1000" = portrait, "1090" = horizontal
     std::vector<MarkLayerInfo> layers;
-    uint32_t main_layer_address = 0;
 };
 
 // Parsed .mark file
@@ -79,11 +79,8 @@ public:
     // Get the number of pages with annotations
     int page_count() const;
 
-    // Check if a specific page has annotations
-    bool has_page(int page) const;
-
     // Get the decoded bitmap as a QPixmap for a specific page
-    // Returns null pixmap if page doesn't exist or decoding fails
+    // Returns null QPixmap if page doesn't exist or decoding fails
     QPixmap get_page_pixmap(int page);
 
     // Get page dimensions
@@ -114,5 +111,6 @@ private:
 
     QString file_path_;
     MarkFileData file_data_;
+    std::set<int> page_set_;
     std::map<int, QPixmap> cached_pixmaps_;
 };

--- a/pdf_viewer/pdf_view_opengl_widget.cpp
+++ b/pdf_viewer/pdf_view_opengl_widget.cpp
@@ -5,6 +5,7 @@
 #include <qapplication.h>
 #include <qdatetime.h>
 #include <qfile.h>
+#include <qimage.h>
 
 #include "pdf_view_opengl_widget.h"
 #include "path.h"
@@ -1666,6 +1667,73 @@ void PdfViewOpenGLWidget::my_render(QPainter* painter) {
 
     painter->endNativePainting();
 
+    // Render Supernote overlays for visible pages (.mark files or PNG exports)
+    // Supernote screen is 1404x1872 pixels (or 1920x2560 for X2 devices).
+    // It scales PDFs to fit within the screen while maintaining aspect ratio,
+    // centering the content with padding on the shorter dimension.
+    for (auto page : visible_pages) {
+        if (!document_view->get_document()->has_supernote_overlay(page)) {
+            continue;
+        }
+
+        QPixmap overlay = document_view->get_document()->get_supernote_overlay(page);
+        if (overlay.isNull()) {
+            continue;
+        }
+
+        // Get overlay dimensions (from the pixmap itself)
+        float supernote_width = static_cast<float>(overlay.width());
+        float supernote_height = static_cast<float>(overlay.height());
+
+        // Get the page dimensions
+        float page_width = document_view->get_document()->get_page_width(page);
+        float page_height = document_view->get_document()->get_page_height(page);
+
+        // Calculate how Supernote would render this PDF page:
+        // It scales to fit while maintaining aspect ratio, then centers.
+        float pdf_aspect = page_height / page_width;
+        float supernote_aspect = supernote_height / supernote_width;
+
+        // Calculate the source rectangle in the overlay (where the PDF content is)
+        QRect source_rect;
+        if (pdf_aspect <= supernote_aspect) {
+            // PDF is relatively wider - scale to fit width, center vertically
+            float scaled_pdf_height = supernote_width * pdf_aspect;
+            float vertical_padding = (supernote_height - scaled_pdf_height) / 2.0f;
+            source_rect = QRect(0, static_cast<int>(vertical_padding),
+                               overlay.width(),
+                               static_cast<int>(scaled_pdf_height));
+        } else {
+            // PDF is relatively taller - scale to fit height, center horizontally
+            float scaled_pdf_width = supernote_height / pdf_aspect;
+            float horizontal_padding = (supernote_width - scaled_pdf_width) / 2.0f;
+            source_rect = QRect(static_cast<int>(horizontal_padding), 0,
+                               static_cast<int>(scaled_pdf_width),
+                               overlay.height());
+        }
+
+        // Get the target page rectangle in window coordinates
+        PagelessDocumentRect page_rect({0, 0, page_width, page_height});
+        DocumentRect doc_rect(page_rect, page);
+        WindowRect window_rect = doc_rect.to_window(document_view);
+
+        QRect target_rect(window_rect.x0, window_rect.y0,
+                         window_rect.x1 - window_rect.x0,
+                         window_rect.y1 - window_rect.y0);
+
+        // Apply color transformation for dark/custom color modes
+        QPixmap overlay_to_draw = overlay;
+        if (color_mode == ColorPalette::Dark || color_mode == ColorPalette::Custom) {
+            QImage img = overlay.toImage();
+            img.invertPixels(QImage::InvertRgb);  // Invert RGB, preserve alpha
+            overlay_to_draw = QPixmap::fromImage(img);
+        }
+
+        // Draw the overlay with transparency
+        painter->setOpacity(0.8);
+        painter->drawPixmap(target_rect, overlay_to_draw, source_rect);
+        painter->setOpacity(1.0);
+    }
 
     if (document_view->get_document()->can_use_highlights()) {
         const std::vector<BookMark>& bookmarks = document_view->get_document()->get_bookmarks();

--- a/pdf_viewer/pdf_view_opengl_widget.cpp
+++ b/pdf_viewer/pdf_view_opengl_widget.cpp
@@ -1672,18 +1672,17 @@ void PdfViewOpenGLWidget::my_render(QPainter* painter) {
     // It scales PDFs to fit within the screen while maintaining aspect ratio,
     // centering the content with padding on the shorter dimension.
     for (auto page : visible_pages) {
-        if (!document_view->get_document()->has_supernote_overlay(page)) {
-            continue;
-        }
-
-        QPixmap overlay = document_view->get_document()->get_supernote_overlay(page);
-        if (overlay.isNull()) {
+        bool use_inverted = (color_mode == ColorPalette::Dark || color_mode == ColorPalette::Custom);
+        const QPixmap* overlay = use_inverted
+            ? document_view->get_document()->get_supernote_overlay_inverted(page)
+            : document_view->get_document()->get_supernote_overlay(page);
+        if (!overlay) {
             continue;
         }
 
         // Get overlay dimensions (from the pixmap itself)
-        float supernote_width = static_cast<float>(overlay.width());
-        float supernote_height = static_cast<float>(overlay.height());
+        float supernote_width = static_cast<float>(overlay->width());
+        float supernote_height = static_cast<float>(overlay->height());
 
         // Get the page dimensions
         float page_width = document_view->get_document()->get_page_width(page);
@@ -1700,16 +1699,16 @@ void PdfViewOpenGLWidget::my_render(QPainter* painter) {
             // PDF is relatively wider - scale to fit width, center vertically
             float scaled_pdf_height = supernote_width * pdf_aspect;
             float vertical_padding = (supernote_height - scaled_pdf_height) / 2.0f;
-            source_rect = QRect(0, static_cast<int>(vertical_padding),
-                               overlay.width(),
-                               static_cast<int>(scaled_pdf_height));
+            source_rect = QRect(0, qRound(vertical_padding),
+                               overlay->width(),
+                               qRound(scaled_pdf_height));
         } else {
             // PDF is relatively taller - scale to fit height, center horizontally
             float scaled_pdf_width = supernote_height / pdf_aspect;
             float horizontal_padding = (supernote_width - scaled_pdf_width) / 2.0f;
-            source_rect = QRect(static_cast<int>(horizontal_padding), 0,
-                               static_cast<int>(scaled_pdf_width),
-                               overlay.height());
+            source_rect = QRect(qRound(horizontal_padding), 0,
+                               qRound(scaled_pdf_width),
+                               overlay->height());
         }
 
         // Get the target page rectangle in window coordinates
@@ -1721,17 +1720,9 @@ void PdfViewOpenGLWidget::my_render(QPainter* painter) {
                          window_rect.x1 - window_rect.x0,
                          window_rect.y1 - window_rect.y0);
 
-        // Apply color transformation for dark/custom color modes
-        QPixmap overlay_to_draw = overlay;
-        if (color_mode == ColorPalette::Dark || color_mode == ColorPalette::Custom) {
-            QImage img = overlay.toImage();
-            img.invertPixels(QImage::InvertRgb);  // Invert RGB, preserve alpha
-            overlay_to_draw = QPixmap::fromImage(img);
-        }
-
         // Draw the overlay with transparency
         painter->setOpacity(0.8);
-        painter->drawPixmap(target_rect, overlay_to_draw, source_rect);
+        painter->drawPixmap(target_rect, *overlay, source_rect);
         painter->setOpacity(1.0);
     }
 

--- a/pdf_viewer_build_config.pro
+++ b/pdf_viewer_build_config.pro
@@ -104,6 +104,7 @@ HEADERS += pdf_viewer/book.h \
            pdf_viewer/utf8/unchecked.h \
            pdf_viewer/RunGuard.h \
            pdf_viewer/OpenWithApplication.h \
+           pdf_viewer/mark_parser.h \
            fzf/fzf.h
 
 
@@ -127,6 +128,7 @@ SOURCES += pdf_viewer/book.cpp \
            pdf_viewer/mysortfilterproxymodel.cpp \
            pdf_viewer/RunGuard.cpp \
            pdf_viewer/OpenWithApplication.cpp \
+           pdf_viewer/mark_parser.cpp \
            fzf/fzf.c
 
 !android{


### PR DESCRIPTION
## Summary

Display handwritten annotations from [Supernote](https://supernote.com/) e-ink tablets as transparent overlays on top of PDF pages. When a PDF has been annotated on a Supernote device, sioyek will automatically detect and render those annotations.

Two formats are supported:

- **`.mark` files** (native) — Supernote stores annotations in a binary `.mark` file alongside the PDF (e.g. `paper.pdf.mark`). This PR adds a parser that reads the file's metadata and RLE-compressed bitmap layers, decodes them into RGBA images, and composites visible layers per page.
- **PNG exports** (fallback) — Supernote can also export annotations as per-page PNG files (`paper.pdf_0.png`, `paper.pdf_1.png`, …). These are loaded directly as pixmaps.

The overlay renderer calculates how the Supernote would have scaled and centered the PDF on its screen (1404×1872 for A5 X/A6 X devices, 1920×2560 for A4 X2/Nomad), then maps the annotation region back onto sioyek's page coordinates. Overlays are drawn at 80% opacity after native painting, and colors are automatically inverted in dark/custom color modes.

## Details

- **New files**: `mark_parser.h` / `mark_parser.cpp` — self-contained `.mark` file parser supporting both standard and X2 device color palettes, multi-layer compositing, and orientation handling
- **`document.h` / `document.cpp`** — lazy-loading API for overlays (`has_supernote_overlay`, `get_supernote_overlay`) with `.mark` taking priority over PNG
- **`pdf_view_opengl_widget.cpp`** — rendering logic that computes source/target rects accounting for aspect ratio differences and Supernote padding
- **`CMakeLists.txt` / `pdf_viewer_build_config.pro`** — add new source files to both build systems

## Notes

- No new dependencies — uses only Qt (QPainter, QImage, QPixmap) and standard library
- No config options needed — overlays are detected and shown automatically when the files exist alongside the PDF
- No impact on PDFs without annotation files — overlay loading is lazy and short-circuits immediately