### PR TITLE
Fix navigate spelling

### DIFF
--- a/pdf_viewer/main_widget.cpp
+++ b/pdf_viewer/main_widget.cpp
@@ -11401,7 +11401,7 @@ QMenuBar* MainWidget::create_main_menu_bar(){
     };
 
     MenuNode* navigate_menu = new MenuNode{
-        "Naviagte",
+        "Navigate",
         "",
         {
             new MenuNode{ "goto_page_with_page_number", "", {} },


### PR DESCRIPTION
Normally I wouldn't make a PR for something so small, but I see this every time I open sioyek.