### PR TITLE
Fix [m] menu keybindings not working on macOS

### DIFF
--- a/pdf_viewer/ui.cpp
+++ b/pdf_viewer/ui.cpp
@@ -1596,6 +1596,29 @@ bool BaseSelectorWidget::eventFilter(QObject* obj, QEvent* event) {
             }
         }
 #endif
+        // On macOS, Ctrl+key combos in QLineEdit are consumed by the Cocoa
+        // text input system (e.g. Ctrl+N → moveDown:, Ctrl+P → moveUp:)
+        // before Qt generates a KeyPress event. They do arrive as
+        // ShortcutOverride events, so we intercept here to dispatch
+        // user-configured [m] menu commands (e.g. control_menu).
+        if (event->type() == QEvent::ShortcutOverride) {
+            QKeyEvent* key_event = static_cast<QKeyEvent*>(event);
+            bool is_ctrl = is_platform_control_pressed(key_event);
+            bool is_alt = key_event->modifiers() & Qt::AltModifier;
+            bool is_shift = key_event->modifiers() & Qt::ShiftModifier;
+            bool is_meta = is_platform_meta_pressed(key_event);
+            if (is_ctrl || is_alt) {
+                MyLineEdit* mle = dynamic_cast<MyLineEdit*>(line_edit);
+                if (mle && mle->main_widget) {
+                    std::unique_ptr<Command> command = mle->main_widget->input_handler->get_menu_command(
+                        mle->main_widget, key_event, is_shift, is_ctrl, is_meta, is_alt);
+                    if (command && command->is_menu_command()) {
+                        mle->main_widget->handle_command_types(std::move(command), 0);
+                        return true;
+                    }
+                }
+            }
+        }
         if (event->type() == QEvent::InputMethod) {
             if (TOUCH_MODE) {
                 QInputMethodEvent* input_event = static_cast<QInputMethodEvent*>(event);
@@ -1895,8 +1918,7 @@ void MyLineEdit::keyPressEvent(QKeyEvent* event) {
         std::unique_ptr<Command> command = main_widget->input_handler->get_menu_command(main_widget, event, is_shift_pressed, is_control_pressed, is_meta_pressed, is_alt_pressed);
 
         if (command && command->is_menu_command()) {
-            // this command will be handled later by our command manager so we ignore it here.
-            event->ignore();
+            main_widget->handle_command_types(std::move(command), 0);
             return;
         }
     }


### PR DESCRIPTION
## Problem

On macOS, `[m]`-prefixed menu keybindings (e.g. `[m]control_menu(down) <C-n>`) silently fail. Ctrl+key combos like Ctrl+N and Ctrl+P never reach `MyLineEdit::keyPressEvent` because macOS's Cocoa text input system intercepts them first — NSTextField's key binding mechanism maps Ctrl+N to `moveDown:`, Ctrl+P to `moveUp:`, etc., consuming the event before Qt can dispatch it.

## Root cause

Two issues:

1. **Cocoa eats Ctrl+key events in text fields.** The Cocoa input handling layer processes these combos at the NSView level, so Qt never generates a `KeyPress` event for them. However, they *do* arrive as `QEvent::ShortcutOverride` events in the `BaseSelectorWidget` event filter, which runs before Cocoa's text handling.

2. **`MyLineEdit::keyPressEvent` drops found commands.** When a menu command is found via `get_menu_command`, the handler calls `event->ignore()` expecting the event to bubble up to `MainWidget::keyPressEvent`. This doesn't work because the widget hierarchy (`MyLineEdit` → `BaseSelectorWidget` → …) doesn't guarantee propagation to `MainWidget`.

## Fix

- Intercept `ShortcutOverride` events in `BaseSelectorWidget::eventFilter` and dispatch matching `[m]` menu commands directly via `handle_command_types`.
- In `MyLineEdit::keyPressEvent`, execute found menu commands immediately instead of ignoring the event.

## Testing

With `keys_user.config`:
```
[m]control_menu(down);[M]screen_down <C-n>
[m]control_menu(up);[M]screen_up <C-p>
```

Verified on macOS (ARM64, Qt 6.11):
- Ctrl+N/P navigate up/down in search menus, bookmark lists, and open-document lists
- Ctrl+N/P scroll the page in normal view
- Backspace still works in menu search fields
- Arrow keys continue to work in all menus