### PR TITLE
AbsoluteRect topleft-bottomright constructor fix

### DIFF
--- a/pdf_viewer/coordinates.cpp
+++ b/pdf_viewer/coordinates.cpp
@@ -119,6 +119,8 @@ int WindowPos::manhattan(const WindowPos& other) {
 }
 
 AbsoluteRect::AbsoluteRect(AbsoluteDocumentPos top_left, AbsoluteDocumentPos bottom_right) {
+    if (top_left.x > bottom_right.x) std::swap(top_left.x, bottom_right.x);
+    if (top_left.y > bottom_right.y) std::swap(top_left.y, bottom_right.y);
     x0 = top_left.x;
     y0 = top_left.y;
     x1 = bottom_right.x;


### PR DESCRIPTION
I noticed that freetext bookmarks wouldn't appear at all if I dragged in any way other than top-left to bottom-right. So I made this quick fix for setting the rect's points to the correct coordinates. Applying the changes to the other rect constructors didn't really do anything, so I left those as is.