### PR TITLE
feat: tab bar GUI with Ctrl+Tab cycling on macOS

### DIFF
--- a/build_and_install.sh
+++ b/build_and_install.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# --- Configuration ---
+INSTALL_DIR="/Applications"
+CLI_WRAPPER="/opt/homebrew/bin/sioyek"
+QT_PATH="/opt/homebrew/opt/qt/bin"
+MAKE_PARALLEL="${MAKE_PARALLEL:-$(sysctl -n hw.logicalcpu 2>/dev/null || echo 4)}"
+
+export PATH="$QT_PATH:$PATH"
+
+# --- Clean mode ---
+if [[ "$1" == "--clean" ]]; then
+    echo "Cleaning build artifacts..."
+    (cd mupdf && make clean 2>/dev/null || true)
+    make clean 2>/dev/null || true
+    rm -rf build
+    echo "Clean complete."
+    if [[ "$2" != "--build" ]]; then
+        exit 0
+    fi
+fi
+
+echo "Building sioyek (parallel=$MAKE_PARALLEL)..."
+
+# --- Build mupdf ---
+echo "==> Building mupdf..."
+cd mupdf
+make HAVE_GLUT=no -j"$MAKE_PARALLEL"
+cd ..
+
+# --- Update deployment target ---
+sed -Ei '' "s/QMAKE_MACOSX_DEPLOYMENT_TARGET.=.[0-9]+/QMAKE_MACOSX_DEPLOYMENT_TARGET = $(sw_vers -productVersion | cut -d. -f1)/" pdf_viewer_build_config.pro
+
+# --- Build sioyek ---
+echo "==> Running qmake6..."
+qmake6 "CONFIG+=non_portable" pdf_viewer_build_config.pro
+
+echo "==> Building sioyek..."
+make -j"$MAKE_PARALLEL"
+
+# --- Package app bundle ---
+echo "==> Packaging app bundle..."
+rm -rf build 2>/dev/null
+mkdir build
+mv sioyek.app build/
+cp -r pdf_viewer/shaders build/sioyek.app/Contents/MacOS/shaders
+cp pdf_viewer/prefs.config build/sioyek.app/Contents/MacOS/prefs.config
+cp pdf_viewer/prefs_user.config build/sioyek.app/Contents/MacOS/prefs_user.config
+cp pdf_viewer/keys.config build/sioyek.app/Contents/MacOS/keys.config
+cp pdf_viewer/keys_user.config build/sioyek.app/Contents/MacOS/keys_user.config
+cp tutorial.pdf build/sioyek.app/Contents/MacOS/tutorial.pdf
+
+# --- Patch Info.plist with PATH ---
+INFO_PLIST="build/sioyek.app/Contents/Info.plist"
+CURRENT_PATH="$PATH"
+/usr/libexec/PlistBuddy -c "Add :LSEnvironment dict" "$INFO_PLIST" 2>/dev/null || true
+/usr/libexec/PlistBuddy -c "Add :LSEnvironment:PATH string $CURRENT_PATH" "$INFO_PLIST" 2>/dev/null || \
+    /usr/libexec/PlistBuddy -c "Set :LSEnvironment:PATH $CURRENT_PATH" "$INFO_PLIST"
+
+# --- Deploy Qt frameworks ---
+echo "==> Running macdeployqt..."
+macdeployqt build/sioyek.app
+
+# --- Sign ---
+echo "==> Signing..."
+codesign --force --deep --sign - build/sioyek.app
+
+# --- Install ---
+echo "==> Installing to $INSTALL_DIR..."
+rm -rf "$INSTALL_DIR/sioyek.app"
+cp -R build/sioyek.app "$INSTALL_DIR/sioyek.app"
+xattr -cr "$INSTALL_DIR/sioyek.app"
+
+# --- CLI wrapper ---
+echo "==> Writing CLI wrapper to $CLI_WRAPPER..."
+cat > "$CLI_WRAPPER" << 'WRAPPER'
+#!/bin/sh
+exec /Applications/sioyek.app/Contents/MacOS/sioyek "$@"
+WRAPPER
+chmod +x "$CLI_WRAPPER"
+
+echo ""
+echo "Done! sioyek installed to $INSTALL_DIR/sioyek.app"
+echo "CLI available at: $CLI_WRAPPER"

--- a/build_and_install.sh
+++ b/build_and_install.sh
@@ -47,12 +47,6 @@ echo "==> Packaging app bundle..."
 rm -rf build 2>/dev/null
 mkdir build
 mv sioyek.app build/
-cp -r pdf_viewer/shaders build/sioyek.app/Contents/MacOS/shaders
-cp pdf_viewer/prefs.config build/sioyek.app/Contents/MacOS/prefs.config
-cp pdf_viewer/prefs_user.config build/sioyek.app/Contents/MacOS/prefs_user.config
-cp pdf_viewer/keys.config build/sioyek.app/Contents/MacOS/keys.config
-cp pdf_viewer/keys_user.config build/sioyek.app/Contents/MacOS/keys_user.config
-cp tutorial.pdf build/sioyek.app/Contents/MacOS/tutorial.pdf
 
 # --- Patch Info.plist with PATH ---
 INFO_PLIST="build/sioyek.app/Contents/Info.plist"
@@ -61,9 +55,18 @@ CURRENT_PATH="$PATH"
 /usr/libexec/PlistBuddy -c "Add :LSEnvironment:PATH string $CURRENT_PATH" "$INFO_PLIST" 2>/dev/null || \
     /usr/libexec/PlistBuddy -c "Set :LSEnvironment:PATH $CURRENT_PATH" "$INFO_PLIST"
 
-# --- Deploy Qt frameworks ---
+# --- Deploy Qt frameworks (before copying non-binary resources to avoid codesign issues) ---
 echo "==> Running macdeployqt..."
 macdeployqt build/sioyek.app
+
+# --- Copy resources after macdeployqt (non-binary files break macdeployqt's codesign) ---
+echo "==> Copying resources..."
+cp -r pdf_viewer/shaders build/sioyek.app/Contents/MacOS/shaders
+cp pdf_viewer/prefs.config build/sioyek.app/Contents/MacOS/prefs.config
+cp pdf_viewer/prefs_user.config build/sioyek.app/Contents/MacOS/prefs_user.config
+cp pdf_viewer/keys.config build/sioyek.app/Contents/MacOS/keys.config
+cp pdf_viewer/keys_user.config build/sioyek.app/Contents/MacOS/keys_user.config
+cp tutorial.pdf build/sioyek.app/Contents/MacOS/tutorial.pdf
 
 # --- Sign ---
 echo "==> Signing..."

--- a/pdf_viewer/config.cpp
+++ b/pdf_viewer/config.cpp
@@ -16,6 +16,8 @@ float CUSTOM_BACKGROUND_COLOR[3] = { 0.18f, 0.204f, 0.251f };
 float CUSTOM_TEXT_COLOR[3] = { 0.847f, 0.871f, 0.914f };
 float STATUS_BAR_COLOR[3] = { 0.0f, 0.0f, 0.0f };
 float STATUS_BAR_TEXT_COLOR[3] = { 1.0f, 1.0f, 1.0f };
+bool SHOW_TAB_BAR = true;
+bool TAB_BAR_AT_TOP = true;
 float UI_TEXT_COLOR[3] = { 1.0f, 1.0f, 1.0f };
 float UI_BACKGROUND_COLOR[3] = { 0.0f, 0.0f, 0.0f };
 float UI_SELECTED_TEXT_COLOR[3] = { 0.0f, 0.0f, 0.0f };
@@ -1034,6 +1036,8 @@ ConfigManager::ConfigManager(const Path& default_path, const Path& auto_path, co
     add_bool(L"add_newlines_when_copying_text", &ADD_NEWLINES_WHEN_COPYING_TEXT);
     add_bool(L"always_copy_selected_text", &ALWAYS_COPY_SELECTED_TEXT);
     add_bool(L"show_statusbar_only_when_hovered", &SHOW_STATUSBAR_ONLY_WHEN_MOUSE_OVER);
+    add_bool(L"show_tab_bar", &SHOW_TAB_BAR);
+    add_bool(L"tab_bar_at_top", &TAB_BAR_AT_TOP);
     add_bool(L"scroll_past_document_ends", &SCROLL_PAST_DOCUMENT_ENDS);
     add_bool(L"horizontal_scroll_past_page_ends", &HORIZONTAL_SCROLL_PAST_PAGE_ENDS);
     add_bool(L"uniform_page_widths", &SAME_WIDTH);

--- a/pdf_viewer/document.cpp
+++ b/pdf_viewer/document.cpp
@@ -4236,6 +4236,7 @@ int DocumentManager::add_tab(const std::wstring& path) {
     int tab_index = get_tab_index(path);
     if (tab_index == -1) {
         tabs.push_back(path);
+        notify_tab_changed();
     }
     return tab_index;
 }
@@ -4244,11 +4245,22 @@ void DocumentManager::remove_tab(const std::wstring& path) {
     int index = get_tab_index(path);
     if (index != -1) {
         tabs.erase(tabs.begin() + index);
+        notify_tab_changed();
     }
 }
 
 std::vector<std::wstring> DocumentManager::get_tabs() {
     return tabs;
+}
+
+void DocumentManager::add_tab_change_listener(std::function<void()> listener) {
+    tab_change_listeners.push_back(std::move(listener));
+}
+
+void DocumentManager::notify_tab_changed() {
+    for (auto& listener : tab_change_listeners) {
+        listener();
+    }
 }
 
 std::wstring Document::detect_paper_name() {

--- a/pdf_viewer/document.h
+++ b/pdf_viewer/document.h
@@ -7,6 +7,7 @@
 #include <mutex>
 #include <map>
 #include <unordered_map>
+#include <functional>
 #include <deque>
 #include <regex>
 
@@ -451,6 +452,7 @@ private:
     std::unordered_map<std::wstring, Document*> cached_documents;
     std::unordered_map<std::string, std::wstring> hash_to_path;
     std::vector<std::wstring> tabs;
+    std::vector<std::function<void()>> tab_change_listeners;
 public:
 
     DocumentManager(fz_context* mupdf_context, DatabaseManager* db_manager, CachedChecksummer* checksummer);
@@ -459,6 +461,8 @@ public:
     int add_tab(const std::wstring& path);
     void remove_tab(const std::wstring& path);
     std::vector<std::wstring> get_tabs();
+    void add_tab_change_listener(std::function<void()> listener);
+    void notify_tab_changed();
 
     Document* get_document(const std::wstring& path);
     std::optional<std::wstring> get_path_from_hash(const std::string& checksum);

--- a/pdf_viewer/input.cpp
+++ b/pdf_viewer/input.cpp
@@ -6412,6 +6412,19 @@ public:
     bool requires_document() { return false; }
 };
 
+class ToggleTabBarCommand : public Command {
+public:
+    static inline const std::string cname = "toggle_tab_bar";
+    static inline const std::string hname = "Toggle tab bar";
+    ToggleTabBarCommand(MainWidget* w) : Command(cname, w) {};
+
+    void perform() {
+        widget->toggle_tab_bar();
+    }
+
+    bool requires_document() { return false; }
+};
+
 
 
 class ClearCurrentPageDrawingsCommand : public Command {
@@ -7268,6 +7281,7 @@ CommandManager::CommandManager(ConfigManager* config_manager) {
     register_command<ToggleSelectHighlightCommand>();
     register_command<OpenLastDocumentCommand>();
     register_command<ToggleStatusbarCommand>();
+    register_command<ToggleTabBarCommand>();
     register_command<StartReadingCommand>();
     register_command<StopReadingCommand>();
     register_command<ToggleReadingCommand>();

--- a/pdf_viewer/main_widget.cpp
+++ b/pdf_viewer/main_widget.cpp
@@ -76,6 +76,7 @@
 #include "book.h"
 #include "utils.h"
 #include "ui.h"
+#include "tab_bar_widget.h"
 #include "pdf_renderer.h"
 #include "document.h"
 #include "document_view.h"
@@ -122,6 +123,8 @@ extern std::wstring PAPER_SEARCH_CONTRIB_PATH;
 extern bool FUZZY_SEARCHING;
 extern bool AUTO_RENAME_DOWNLOADED_PAPERS;
 extern bool SHOW_STATUSBAR_ONLY_WHEN_MOUSE_OVER;
+extern bool SHOW_TAB_BAR;
+extern bool TAB_BAR_AT_TOP;
 
 extern float TEXT_SELECTION_MINIMUM_DISTANCE;
 extern float VISUAL_MARK_NEXT_PAGE_FRACTION;
@@ -489,9 +492,39 @@ void MainWidget::resizeEvent(QResizeEvent* resize_event) {
     }
 
     int status_bar_height = get_status_bar_height();
+    int tab_bar_h = get_tab_bar_height();
+
+    // Position tab bar
+    if (tab_bar_widget != nullptr) {
+        bool show_tabs = should_show_tab_bar() && document_manager->get_tabs().size() > 1;
+        if (show_tabs) {
+            if (TAB_BAR_AT_TOP) {
+                tab_bar_widget->move(0, 0);
+            } else {
+                tab_bar_widget->move(0, main_window_height - status_bar_height - tab_bar_h);
+            }
+            tab_bar_widget->resize(main_window_width, tab_bar_h);
+            tab_bar_widget->show();
+            tab_bar_widget->update_tabs();
+        } else {
+            tab_bar_widget->hide();
+            tab_bar_h = 0;
+        }
+    } else {
+        tab_bar_h = 0;
+    }
+
+    // Adjust layout margins so OpenGL widget doesn't underlap tab bar or status bar
+    QVBoxLayout* vlayout = qobject_cast<QVBoxLayout*>(central_widget->layout());
+    if (vlayout) {
+        int top_margin = TAB_BAR_AT_TOP ? tab_bar_h : 0;
+        int bot_margin = (!TAB_BAR_AT_TOP ? tab_bar_h : 0) + status_bar_height;
+        vlayout->setContentsMargins(0, top_margin, 0, bot_margin);
+    }
 
     if (text_command_line_edit_container != nullptr) {
-        text_command_line_edit_container->move(0, 0);
+        int cmd_y = (TAB_BAR_AT_TOP && tab_bar_h > 0) ? tab_bar_h : 0;
+        text_command_line_edit_container->move(0, cmd_y);
         text_command_line_edit_container->resize(main_window_width, status_bar_height);
     }
 
@@ -937,7 +970,17 @@ MainWidget::MainWidget(fz_context* mupdf_context,
 
     status_label->setLayout(status_label_layout);
 
-    opengl_widget->stackUnder(status_label);
+    // Create tab bar widget
+    tab_bar_widget = new TabBarWidget(this);
+    tab_bar_widget->setFont(QFont(get_status_font_face_name()));
+    tab_bar_widget->hide(); // hidden until we have >1 tab
+
+    document_manager->add_tab_change_listener([this]() {
+        QMetaObject::invokeMethod(this, [this]() { update_tab_bar(); }, Qt::QueuedConnection);
+    });
+
+    opengl_widget->stackUnder(tab_bar_widget);
+    tab_bar_widget->stackUnder(status_label);
 
     // automatically open the helper window in second monitor
     int num_screens = QGuiApplication::screens().size();
@@ -4954,6 +4997,44 @@ void MainWidget::toggle_statusbar() {
     else {
         status_label->show();
     }
+}
+
+void MainWidget::toggle_tab_bar() {
+    should_show_tab_bar_ = !should_show_tab_bar_;
+    // Trigger re-layout by faking a resize
+    QResizeEvent event(size(), size());
+    resizeEvent(&event);
+}
+
+bool MainWidget::should_show_tab_bar() {
+    return should_show_tab_bar_ && SHOW_TAB_BAR;
+}
+
+void MainWidget::update_tab_bar() {
+    if (tab_bar_widget) {
+        // Re-layout in case tab count changed (show/hide logic)
+        QResizeEvent event(size(), size());
+        resizeEvent(&event);
+    }
+}
+
+int MainWidget::get_tab_bar_height() {
+    return get_status_bar_height();
+}
+
+void MainWidget::handle_close_tab(const std::wstring& path) {
+    auto tabs = document_manager->get_tabs();
+    if (tabs.size() <= 1) return; // don't close the last tab
+
+    bool is_active = (doc() && doc()->get_path() == path);
+    if (is_active) {
+        // Switch to an adjacent tab before closing
+        int idx = get_current_tab_index();
+        int next = (idx + 1) % (int)tabs.size();
+        if (next == idx && tabs.size() > 1) next = 0;
+        handle_goto_tab(tabs[next]);
+    }
+    document_manager->remove_tab(path);
 }
 
 void MainWidget::toggle_titlebar() {

--- a/pdf_viewer/main_widget.cpp
+++ b/pdf_viewer/main_widget.cpp
@@ -10172,6 +10172,7 @@ void MainWidget::handle_goto_tab(const std::wstring& path) {
 
     push_state();
     open_document(path);
+    document_manager->notify_tab_changed();
 }
 
 void MainWidget::handle_rename(std::wstring new_name) {

--- a/pdf_viewer/main_widget.cpp
+++ b/pdf_viewer/main_widget.cpp
@@ -6583,15 +6583,21 @@ bool MainWidget::event(QEvent* event) {
 
     QTabletEvent* te = dynamic_cast<QTabletEvent*>(event);
     QKeyEvent* ke = dynamic_cast<QKeyEvent*>(event);
-    if (ke && (ke->type() == QEvent::KeyPress)) {
-        // Apparently Qt doesn't send keyPressEvent for tab and backtab anymore, so we have to
-        // manually handle them here.
-        // todo: make sure this doesn't cause problems on linux and mac
-        //if (((ke->key() == Qt::Key_Tab) && (ke->modifiers() == 0)) || ((ke->key() == Qt::Key_Backtab) && (ke->modifiers() == Qt::ShiftModifier))) {
-        //    if (event->isAccepted()) {
-        //        key_event(false, ke);
-        //    }
-        //}
+    // Qt eats Tab/Backtab KeyPress events for focus-chain navigation before
+    // keyPressEvent() is called. Intercept the ShortcutOverride and dispatch
+    // tab cycling directly — the keybinding matcher's key normalization has
+    // issues with Backtab events from ShortcutOverride.
+    if (ke && ke->type() == QEvent::ShortcutOverride) {
+        if ((ke->key() == Qt::Key_Tab || ke->key() == Qt::Key_Backtab) &&
+            ((ke->modifiers() & Qt::ControlModifier) || (ke->modifiers() & Qt::MetaModifier))) {
+            if (ke->key() == Qt::Key_Backtab) {
+                goto_ith_next_tab(-1);
+            } else {
+                goto_ith_next_tab(1);
+            }
+            event->accept();
+            return true;
+        }
     }
 
     if (event->type() == QEvent::WindowActivate) {

--- a/pdf_viewer/main_widget.h
+++ b/pdf_viewer/main_widget.h
@@ -329,6 +329,14 @@ public:
     bool should_show_status_label_ = true;
     bool should_show_status_label(bool check_network=true);
 
+    class TabBarWidget* tab_bar_widget = nullptr;
+    bool should_show_tab_bar_ = true;
+    bool should_show_tab_bar();
+    void toggle_tab_bar();
+    void update_tab_bar();
+    int get_tab_bar_height();
+    void handle_close_tab(const std::wstring& path);
+
     // the location of current character in sioyek's typing minigame
     std::optional<CharacterAddress> typing_location;
 

--- a/pdf_viewer/tab_bar_widget.cpp
+++ b/pdf_viewer/tab_bar_widget.cpp
@@ -1,0 +1,221 @@
+#include "tab_bar_widget.h"
+#include "main_widget.h"
+#include "document.h"
+#include "utils.h"
+
+#include <QPainter>
+#include <QFileInfo>
+#include <QToolTip>
+
+extern float STATUS_BAR_COLOR[3];
+extern float STATUS_BAR_TEXT_COLOR[3];
+extern bool SHOW_TAB_BAR;
+extern bool TAB_BAR_AT_TOP;
+
+static QColor color_from_float3(float* c, int alpha = 255) {
+    return QColor(c[0] * 255, c[1] * 255, c[2] * 255, alpha);
+}
+
+static const int TAB_PADDING = 12;
+static const int CLOSE_BTN_SIZE = 12;
+static const int CLOSE_BTN_MARGIN = 6;
+static const int MIN_TAB_WIDTH = 80;
+static const int MAX_TAB_WIDTH = 250;
+static const int ACCENT_HEIGHT = 2;
+
+TabBarWidget::TabBarWidget(MainWidget* parent)
+    : QWidget(parent), main_widget(parent)
+{
+    setMouseTracking(true);
+}
+
+void TabBarWidget::update_tabs() {
+    recompute_layout(width(), height());
+    update();
+}
+
+void TabBarWidget::recompute_layout(int w, int h) {
+    tab_infos.clear();
+
+    auto tabs = main_widget->document_manager->get_tabs();
+    int current_index = main_widget->get_current_tab_index();
+
+    if (tabs.empty()) return;
+
+    QFont font = this->font();
+    QFontMetrics fm(font);
+
+    // Compute ideal widths, then clamp
+    std::vector<int> widths;
+    int total_width = 0;
+    for (size_t i = 0; i < tabs.size(); i++) {
+        QString label = QFileInfo(QString::fromStdWString(tabs[i])).fileName();
+        if (label.isEmpty()) label = "untitled";
+        int text_w = fm.horizontalAdvance(label);
+        int tab_w = text_w + TAB_PADDING * 2 + CLOSE_BTN_SIZE + CLOSE_BTN_MARGIN * 2;
+        tab_w = std::max(MIN_TAB_WIDTH, std::min(MAX_TAB_WIDTH, tab_w));
+        widths.push_back(tab_w);
+        total_width += tab_w;
+    }
+
+    // If total exceeds widget width, shrink tabs proportionally
+    if (total_width > w && tabs.size() > 0) {
+        int per_tab = w / (int)tabs.size();
+        per_tab = std::max(MIN_TAB_WIDTH, per_tab);
+        for (size_t i = 0; i < widths.size(); i++) {
+            widths[i] = per_tab;
+        }
+        total_width = per_tab * (int)tabs.size();
+    }
+
+    // Clamp scroll offset
+    int max_scroll = std::max(0, total_width - w);
+    scroll_offset = std::max(0, std::min(scroll_offset, max_scroll));
+
+    int x = -scroll_offset;
+    for (size_t i = 0; i < tabs.size(); i++) {
+        TabInfo info;
+        info.path = tabs[i];
+        info.label = QFileInfo(QString::fromStdWString(tabs[i])).fileName();
+        if (info.label.isEmpty()) info.label = "untitled";
+        info.is_active = ((int)i == current_index);
+        info.rect = QRect(x, 0, widths[i], h);
+
+        // Close button: right side of tab, vertically centered
+        int close_x = x + widths[i] - CLOSE_BTN_SIZE - CLOSE_BTN_MARGIN;
+        int close_y = (h - CLOSE_BTN_SIZE) / 2;
+        info.close_rect = QRect(close_x, close_y, CLOSE_BTN_SIZE, CLOSE_BTN_SIZE);
+
+        tab_infos.push_back(info);
+        x += widths[i];
+    }
+}
+
+void TabBarWidget::paintEvent(QPaintEvent*) {
+    if (tab_infos.empty()) {
+        recompute_layout(width(), height());
+    }
+
+    QPainter painter(this);
+    painter.setRenderHint(QPainter::Antialiasing);
+
+    QColor bg_color = color_from_float3(STATUS_BAR_COLOR);
+    QColor text_color = color_from_float3(STATUS_BAR_TEXT_COLOR);
+    QColor active_bg = bg_color.lighter(150);
+    QColor hover_bg = bg_color.lighter(125);
+    QColor inactive_text = color_from_float3(STATUS_BAR_TEXT_COLOR, 140);
+    QColor accent_color = text_color;
+    QColor close_color = color_from_float3(STATUS_BAR_TEXT_COLOR, 100);
+    QColor close_hover = text_color;
+
+    // Background
+    painter.fillRect(rect(), bg_color);
+
+    for (size_t i = 0; i < tab_infos.size(); i++) {
+        const TabInfo& tab = tab_infos[i];
+
+        // Skip tabs entirely outside visible area
+        if (tab.rect.right() < 0 || tab.rect.left() > width()) continue;
+
+        // Tab background
+        if (tab.is_active) {
+            painter.fillRect(tab.rect, active_bg);
+        } else if ((int)i == hovered_index) {
+            painter.fillRect(tab.rect, hover_bg);
+        }
+
+        // Active tab accent line
+        if (tab.is_active) {
+            QRect accent_rect;
+            if (TAB_BAR_AT_TOP) {
+                accent_rect = QRect(tab.rect.left(), tab.rect.bottom() - ACCENT_HEIGHT + 1, tab.rect.width(), ACCENT_HEIGHT);
+            } else {
+                accent_rect = QRect(tab.rect.left(), 0, tab.rect.width(), ACCENT_HEIGHT);
+            }
+            painter.fillRect(accent_rect, accent_color);
+        }
+
+        // Separator line between tabs
+        if (i > 0 && !tab.is_active && (i == 0 || !tab_infos[i-1].is_active)) {
+            painter.setPen(QPen(color_from_float3(STATUS_BAR_TEXT_COLOR, 40), 1));
+            painter.drawLine(tab.rect.left(), tab.rect.top() + 4, tab.rect.left(), tab.rect.bottom() - 4);
+        }
+
+        // Label text (truncated with ellipsis)
+        painter.setPen(tab.is_active ? text_color : inactive_text);
+        QRect text_rect = tab.rect.adjusted(TAB_PADDING, 0, -(CLOSE_BTN_SIZE + CLOSE_BTN_MARGIN * 2), 0);
+        QString elided = painter.fontMetrics().elidedText(tab.label, Qt::ElideRight, text_rect.width());
+        painter.drawText(text_rect, Qt::AlignVCenter | Qt::AlignLeft, elided);
+
+        // Close button (×)
+        bool close_hovered = ((int)i == hovered_index && hover_on_close);
+        painter.setPen(close_hovered ? close_hover : close_color);
+        QFont close_font = painter.font();
+        close_font.setPixelSize(CLOSE_BTN_SIZE);
+        close_font.setBold(close_hovered);
+        painter.setFont(close_font);
+        painter.drawText(tab.close_rect, Qt::AlignCenter, QString::fromUtf8("\u00d7"));
+        painter.setFont(font());
+    }
+}
+
+int TabBarWidget::tab_at(QPoint pos) {
+    for (size_t i = 0; i < tab_infos.size(); i++) {
+        if (tab_infos[i].rect.contains(pos)) return (int)i;
+    }
+    return -1;
+}
+
+void TabBarWidget::mousePressEvent(QMouseEvent* event) {
+    if (event->button() != Qt::LeftButton) return;
+
+    int idx = tab_at(event->pos());
+    if (idx < 0 || idx >= (int)tab_infos.size()) return;
+
+    if (tab_infos[idx].close_rect.contains(event->pos())) {
+        // Close this tab
+        main_widget->handle_close_tab(tab_infos[idx].path);
+    } else {
+        // Switch to this tab
+        main_widget->handle_goto_tab(tab_infos[idx].path);
+    }
+}
+
+void TabBarWidget::mouseMoveEvent(QMouseEvent* event) {
+    int idx = tab_at(event->pos());
+    bool on_close = (idx >= 0 && idx < (int)tab_infos.size() && tab_infos[idx].close_rect.contains(event->pos()));
+
+    if (idx != hovered_index || on_close != hover_on_close) {
+        hovered_index = idx;
+        hover_on_close = on_close;
+        setCursor(idx >= 0 ? Qt::PointingHandCursor : Qt::ArrowCursor);
+
+        // Tooltip: show full path
+        if (idx >= 0 && !on_close) {
+            setToolTip(QString::fromStdWString(tab_infos[idx].path));
+        } else {
+            setToolTip(QString());
+        }
+
+        update();
+    }
+}
+
+void TabBarWidget::leaveEvent(QEvent*) {
+    if (hovered_index != -1) {
+        hovered_index = -1;
+        hover_on_close = false;
+        setCursor(Qt::ArrowCursor);
+        update();
+    }
+}
+
+void TabBarWidget::wheelEvent(QWheelEvent* event) {
+    scroll_offset -= event->angleDelta().y();
+    int total_width = 0;
+    for (auto& t : tab_infos) total_width += t.rect.width();
+    int max_scroll = std::max(0, total_width - width());
+    scroll_offset = std::max(0, std::min(scroll_offset, max_scroll));
+    recompute_layout(width(), height());
+    update();
+}

--- a/pdf_viewer/tab_bar_widget.h
+++ b/pdf_viewer/tab_bar_widget.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <QWidget>
+#include <QPaintEvent>
+#include <QMouseEvent>
+#include <QWheelEvent>
+#include <QRect>
+#include <QString>
+#include <string>
+#include <vector>
+
+class MainWidget;
+
+class TabBarWidget : public QWidget {
+    Q_OBJECT
+public:
+    TabBarWidget(MainWidget* parent);
+    void update_tabs();
+
+protected:
+    void paintEvent(QPaintEvent* event) override;
+    void mousePressEvent(QMouseEvent* event) override;
+    void mouseMoveEvent(QMouseEvent* event) override;
+    void leaveEvent(QEvent* event) override;
+    void wheelEvent(QWheelEvent* event) override;
+
+private:
+    struct TabInfo {
+        QRect rect;
+        QRect close_rect;
+        std::wstring path;
+        QString label;
+        bool is_active;
+    };
+
+    MainWidget* main_widget;
+    std::vector<TabInfo> tab_infos;
+    int hovered_index = -1;
+    bool hover_on_close = false;
+    int scroll_offset = 0;
+
+    void recompute_layout(int w, int h);
+    int tab_at(QPoint pos);
+};

--- a/pdf_viewer/ui.cpp
+++ b/pdf_viewer/ui.cpp
@@ -1655,7 +1655,7 @@ bool BaseSelectorWidget::eventFilter(QObject* obj, QEvent* event) {
                 //QCoreApplication::postEvent(tree_view, key_event);
                 return true;
             }
-            if (key_event->key() == Qt::Key_Tab) {
+            if (key_event->key() == Qt::Key_Tab && !is_control_pressed && !is_alt_pressed) {
                 QKeyEvent* new_key_event = new QKeyEvent(key_event->type(), Qt::Key_Down, key_event->modifiers());
                 QCoreApplication::postEvent(get_view(), new_key_event);
                 return true;
@@ -1670,7 +1670,7 @@ bool BaseSelectorWidget::eventFilter(QObject* obj, QEvent* event) {
                 QCoreApplication::postEvent(get_view(), new_key_event);
                 return true;
             }
-            if (key_event->key() == Qt::Key_Backtab) {
+            if (key_event->key() == Qt::Key_Backtab && !is_control_pressed && !is_alt_pressed) {
                 QKeyEvent* new_key_event = new QKeyEvent(key_event->type(), Qt::Key_Up, key_event->modifiers());
                 QCoreApplication::postEvent(get_view(), new_key_event);
                 return true;

--- a/pdf_viewer/ui.cpp
+++ b/pdf_viewer/ui.cpp
@@ -1596,6 +1596,29 @@ bool BaseSelectorWidget::eventFilter(QObject* obj, QEvent* event) {
             }
         }
 #endif
+        // On macOS, Ctrl+key combos in QLineEdit are consumed by the Cocoa
+        // text input system (e.g. Ctrl+N → moveDown:, Ctrl+P → moveUp:)
+        // before Qt generates a KeyPress event. They do arrive as
+        // ShortcutOverride events, so we intercept here to dispatch
+        // user-configured [m] menu commands (e.g. control_menu).
+        if (event->type() == QEvent::ShortcutOverride) {
+            QKeyEvent* key_event = static_cast<QKeyEvent*>(event);
+            bool is_ctrl = is_platform_control_pressed(key_event);
+            bool is_alt = key_event->modifiers() & Qt::AltModifier;
+            bool is_shift = key_event->modifiers() & Qt::ShiftModifier;
+            bool is_meta = is_platform_meta_pressed(key_event);
+            if (is_ctrl || is_alt) {
+                MyLineEdit* mle = dynamic_cast<MyLineEdit*>(line_edit);
+                if (mle && mle->main_widget) {
+                    std::unique_ptr<Command> command = mle->main_widget->input_handler->get_menu_command(
+                        mle->main_widget, key_event, is_shift, is_ctrl, is_meta, is_alt);
+                    if (command && command->is_menu_command()) {
+                        mle->main_widget->handle_command_types(std::move(command), 0);
+                        return true;
+                    }
+                }
+            }
+        }
         if (event->type() == QEvent::InputMethod) {
             if (TOUCH_MODE) {
                 QInputMethodEvent* input_event = static_cast<QInputMethodEvent*>(event);
@@ -1895,8 +1918,7 @@ void MyLineEdit::keyPressEvent(QKeyEvent* event) {
         std::unique_ptr<Command> command = main_widget->input_handler->get_menu_command(main_widget, event, is_shift_pressed, is_control_pressed, is_meta_pressed, is_alt_pressed);
 
         if (command && command->is_menu_command()) {
-            // this command will be handled later by our command manager so we ignore it here.
-            event->ignore();
+            main_widget->handle_command_types(std::move(command), 0);
             return;
         }
     }

--- a/pdf_viewer/ui.cpp
+++ b/pdf_viewer/ui.cpp
@@ -1596,24 +1596,28 @@ bool BaseSelectorWidget::eventFilter(QObject* obj, QEvent* event) {
             }
         }
 #endif
-        // On macOS, Ctrl+key combos in QLineEdit are consumed by the Cocoa
-        // text input system (e.g. Ctrl+N → moveDown:, Ctrl+P → moveUp:)
-        // before Qt generates a KeyPress event. They do arrive as
-        // ShortcutOverride events, so we intercept here to dispatch
-        // user-configured [m] menu commands (e.g. control_menu).
+        // On macOS, Ctrl+N/P in QLineEdit are converted by Cocoa's text
+        // input system to moveDown:/moveUp: which arrive as Key_Down/Key_Up
+        // KeyPress events (handled at line ~1644). We accept the
+        // ShortcutOverride so Qt doesn't consume it as a shortcut, but
+        // do NOT dispatch the command here — Cocoa's synthetic Key_Down/Up
+        // already does the work. Dispatching here too would double-move.
         if (event->type() == QEvent::ShortcutOverride) {
             QKeyEvent* key_event = static_cast<QKeyEvent*>(event);
             bool is_ctrl = is_platform_control_pressed(key_event);
             bool is_alt = key_event->modifiers() & Qt::AltModifier;
-            bool is_shift = key_event->modifiers() & Qt::ShiftModifier;
-            bool is_meta = is_platform_meta_pressed(key_event);
             if (is_ctrl || is_alt) {
                 MyLineEdit* mle = dynamic_cast<MyLineEdit*>(line_edit);
                 if (mle && mle->main_widget) {
+                    bool is_shift = key_event->modifiers() & Qt::ShiftModifier;
+                    bool is_meta = is_platform_meta_pressed(key_event);
                     std::unique_ptr<Command> command = mle->main_widget->input_handler->get_menu_command(
                         mle->main_widget, key_event, is_shift, is_ctrl, is_meta, is_alt);
                     if (command && command->is_menu_command()) {
-                        mle->main_widget->handle_command_types(std::move(command), 0);
+                        // Accept so Qt doesn't eat it; Cocoa will generate
+                        // the equivalent Key_Down/Up which the KeyPress
+                        // handler below forwards to the list view.
+                        event->accept();
                         return true;
                     }
                 }

--- a/pdf_viewer_build_config.pro
+++ b/pdf_viewer_build_config.pro
@@ -96,6 +96,7 @@ HEADERS += pdf_viewer/book.h \
            pdf_viewer/sqlite3ext.h \
            pdf_viewer/ui.h \
            pdf_viewer/tab_bar_widget.h \
+           pdf_viewer/color_wheel_widget.h \
            pdf_viewer/path.h \
            pdf_viewer/utf8.h \
            pdf_viewer/utils.h \
@@ -124,6 +125,7 @@ SOURCES += pdf_viewer/book.cpp \
            pdf_viewer/sqlite3.c \
            pdf_viewer/ui.cpp \
            pdf_viewer/tab_bar_widget.cpp \
+           pdf_viewer/color_wheel_widget.cpp \
            pdf_viewer/path.cpp \
            pdf_viewer/utils.cpp \
            pdf_viewer/mysortfilterproxymodel.cpp \
@@ -215,7 +217,7 @@ mac {
     QMAKE_CXXFLAGS += -std=c++17
     LIBS += -ldl -L$$PWD/mupdf/build/release -lmupdf -lmupdf-third -lmupdf-threads -lz
     CONFIG+=sdk_no_version_check
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 15
+    QMAKE_MACOSX_DEPLOYMENT_TARGET = 26
     ICON = pdf_viewer\icon2.ico
     QMAKE_INFO_PLIST = resources/Info.plist
     LIBS += -framework AppKit

--- a/pdf_viewer_build_config.pro
+++ b/pdf_viewer_build_config.pro
@@ -95,6 +95,7 @@ HEADERS += pdf_viewer/book.h \
            pdf_viewer/sqlite3.h \
            pdf_viewer/sqlite3ext.h \
            pdf_viewer/ui.h \
+           pdf_viewer/tab_bar_widget.h \
            pdf_viewer/path.h \
            pdf_viewer/utf8.h \
            pdf_viewer/utils.h \
@@ -122,6 +123,7 @@ SOURCES += pdf_viewer/book.cpp \
            pdf_viewer/coordinates.cpp \
            pdf_viewer/sqlite3.c \
            pdf_viewer/ui.cpp \
+           pdf_viewer/tab_bar_widget.cpp \
            pdf_viewer/path.cpp \
            pdf_viewer/utils.cpp \
            pdf_viewer/mysortfilterproxymodel.cpp \


### PR DESCRIPTION
## Summary
- Add a visual tab bar showing open documents with close buttons
- Implement Ctrl+Tab / Ctrl+Shift+Tab for tab cycling on macOS
- Fix macOS Ctrl+N/P double-move in menu selection dialogs
- Fix macdeployqt codesign ordering in build script
- Fix tab bar highlight not updating when clicking tabs

## Test plan
- [ ] Open multiple PDFs, verify tab bar appears with document names
- [ ] Click tabs to switch documents, verify highlight follows
- [ ] Ctrl+Tab / Ctrl+Shift+Tab cycles through tabs
- [ ] Close tabs via X button
- [ ] Ctrl+N/P moves one entry at a time in search/command menus
- [ ] Build script produces valid .app bundle