### PR TITLE
Document <D-...> modifier and macOS Ctrl/Cmd behavior in keys.config

### DIFF
--- a/pdf_viewer/keys.config
+++ b/pdf_viewer/keys.config
@@ -3,6 +3,7 @@
 # the syntax is pretty simple. Some examples:
 #command        k             (command is executed when k is pressed)
 #command        <C-k>         (command is executed when k is pressed while holding control)
+#command        <D-k>         (command is executed when k is pressed while holding command/meta)
 #command        K             (command is executed when K is entered, which is shift+k)
 #command        <A-k>         (command is executed when k is pressed while holding alt)
 #command        +             (command is executed when = is pressed while holding shift)
@@ -11,6 +12,8 @@
 #command        gt            (command is executed when g is pressed and then t is pressed)
 #command        g<C-n>Dt  (command is executed when g is pressed and then n is pressed while holding\
 #                               control and then d is pressed while holding shift and then t is pressed)
+# Note: on macOS, Qt swaps Ctrl and Cmd by default (see Qt::AA_MacDontSwapCtrlAndMeta),
+# so <C-k> binds to the physical Control key and <D-k> binds to the physical Command (⌘) key.
 # you can execute multiple commands using the following syntax:
 #command1;command2;command3        <keybinding>
 # for more information see the documentation at https://sioyek-documentation.readthedocs.io/


### PR DESCRIPTION
`pdf_viewer/input.cpp` accepts `C`, `D`, `A`, `S` as modifier tokens,
but the syntax-help block at the top of `pdf_viewer/keys.config` only
shows `<C-...>` and `<A-...>`. `<D-...>` (command/meta) is
undiscoverable without reading the parser.

On macOS this matters: `<C-k>` binds to physical Control,
`<D-k>` binds to physical Command (⌘) — a Mac user expecting ⌘C from
`copy <C-c>` gets physical Ctrl+C instead.

Doc-only change to the comment block.