### PR TITLE
Add missing <optional> includes for GCC 16 compatibility

### DIFF
--- a/pdf_viewer/book.h
+++ b/pdf_viewer/book.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vector>
+#include <optional>
 #include <string>
 #include <variant>
 #include <mupdf/fitz.h>

--- a/pdf_viewer/database.h
+++ b/pdf_viewer/database.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <iostream>
+#include <optional>
 #include <vector>
 #include <iostream>
 #include <string>


### PR DESCRIPTION
GCC 16 no longer transitively includes <optional> via <variant>, causing compilation failures in pdf_viewer/book.h and pdf_viewer/database.h which use std::optional<...> without an explicit include.

Files Changed:
- pdf_viewer/book.h: Added #include <optional>
- pdf_viewer/database.h: Added #include <optional>

Testing:
- Builds cleanly with GCC 16.x, Qt 6.7, libmupdf 1.27 on Arch Linux
- Upstream commit aaf8bd0c
- sioyek --help runs successfully after build
- No functional changes — only header includes