### PR TITLE
Fixes ligature transposition bug #1617

### DIFF
--- a/pdf_viewer/utils.cpp
+++ b/pdf_viewer/utils.cpp
@@ -505,7 +505,7 @@ std::vector<fz_stext_char*> reorder_stext_line(fz_stext_line* line) {
             });
     }
     else {
-        std::sort(reordered_chars.begin(), reordered_chars.end(), [](fz_stext_char* lhs, fz_stext_char* rhs) {
+        std::stable_sort(reordered_chars.begin(), reordered_chars.end(), [](fz_stext_char* lhs, fz_stext_char* rhs) {
             return (lhs->quad.lr.x <= rhs->quad.lr.x) && (lhs->quad.ll.x < rhs->quad.ll.x);
             });
     }


### PR DESCRIPTION
Hi ahrm,

I found the culprit for #1617. It's basically identical to 627c3ef041eeeebd290b3ae4c78b9d3cfa0e140b. The `reorder_stext_line` utility function used an unstable sort which I'm guessing is why you couldn't reproduce the issue.

As an aside, it might be worth adding a comment to the reordering function. It looks a bit odd (redundant) at first to do the reordering in both cases. I think it was added in 5016bc5e432b5db95b80ade62b0b8af44dcbf598 as part of handling malformed text.