### PR TITLE
Hide typed password when opening password protected files

### DIFF
--- a/pdf_viewer/input.cpp
+++ b/pdf_viewer/input.cpp
@@ -947,6 +947,10 @@ std::optional<QString> Command::get_file_path_requirement_root_dir(){
     return {};
 }
 
+bool Command::masks_text() {
+    return false;
+}
+
 void Command::perform_up() {
 }
 
@@ -5526,6 +5530,10 @@ public:
 
     std::string text_requirement_name() {
         return "Password";
+    }
+
+    bool masks_text() override {
+        return true;
     }
 };
 

--- a/pdf_viewer/input.h
+++ b/pdf_viewer/input.h
@@ -74,6 +74,7 @@ public:
     virtual void on_key_hold();
     virtual void on_text_change(const QString& new_text);
     virtual std::optional<QString> get_file_path_requirement_root_dir();
+    virtual bool masks_text();
 
     void set_next_requirement_with_string(std::wstring str);
 

--- a/pdf_viewer/main_widget.cpp
+++ b/pdf_viewer/main_widget.cpp
@@ -3571,7 +3571,7 @@ void MainWidget::show_mark_selector() {
         });
 }
 
-void MainWidget::show_textbar(const std::wstring& command_name, const std::wstring& initial_value) {
+void MainWidget::show_textbar(const std::wstring& command_name, const std::wstring& initial_value, bool mask_input) {
     QString init = "";
     text_suggestion_index = 0;
 
@@ -3580,7 +3580,7 @@ void MainWidget::show_textbar(const std::wstring& command_name, const std::wstri
     }
     if (TOUCH_MODE) {
 
-        TouchTextEdit* edit_widget = new TouchTextEdit(QString::fromStdWString(command_name), init, this);
+        TouchTextEdit* edit_widget = new TouchTextEdit(QString::fromStdWString(command_name), init, mask_input, this);
 
         QObject::connect(edit_widget, &TouchTextEdit::confirmed, [&](QString text) {
             pop_current_widget();
@@ -3603,6 +3603,11 @@ void MainWidget::show_textbar(const std::wstring& command_name, const std::wstri
             text_command_line_edit->setText(init);
         }
         text_command_line_edit_label->setText(QString::fromStdWString(command_name));
+        if (mask_input) {
+            text_command_line_edit->setEchoMode(QLineEdit::Password);
+        } else {
+            text_command_line_edit->setEchoMode(QLineEdit::Normal);
+        }
         text_command_line_edit_container->show();
         text_command_line_edit->setFocus();
         if (initial_value.size() > 0) {
@@ -5730,7 +5735,7 @@ void MainWidget::advance_command(std::unique_ptr<Command> new_command, std::wstr
 
             Requirement next_requirement = pending_command_instance->next_requirement(this).value();
             if (next_requirement.type == RequirementType::Text) {
-                show_textbar(utf8_decode(next_requirement.name), pending_command_instance->get_text_default_value());
+                show_textbar(utf8_decode(next_requirement.name), pending_command_instance->get_text_default_value(), pending_command_instance->masks_text());
             }
             else if (next_requirement.type == RequirementType::Symbol) {
                 if (TOUCH_MODE) {
@@ -10467,6 +10472,7 @@ DocumentView* MainWidget::helper_document_view(){
 
 void MainWidget::hide_command_line_edit(){
     text_command_line_edit->setText("");
+    text_command_line_edit->setEchoMode(QLineEdit::Normal);
     text_command_line_edit_container->hide();
     hide_command_hints();
     text_suggestion_index = 0;

--- a/pdf_viewer/main_widget.h
+++ b/pdf_viewer/main_widget.h
@@ -450,7 +450,7 @@ public:
     void change_selected_bookmark_text(const std::wstring& new_text);
     void change_selected_highlight_text_annot(const std::wstring& new_text);
     char get_current_selected_highlight_type();
-    void show_textbar(const std::wstring& command_name, const std::wstring& initial_value = L"");
+    void show_textbar(const std::wstring& command_name, const std::wstring& initial_value = L"", bool mask_input = false);
     void show_mark_selector();
     void toggle_two_window_mode();
     void toggle_window_configuration();

--- a/pdf_viewer/touchui/TouchTextEdit.cpp
+++ b/pdf_viewer/touchui/TouchTextEdit.cpp
@@ -2,7 +2,7 @@
 #include "utils.h"
 
 
-TouchTextEdit::TouchTextEdit(QString name, QString initial_value, QWidget* parent) : QWidget(parent) {
+TouchTextEdit::TouchTextEdit(QString name, QString initial_value, bool is_password, QWidget* parent) : QWidget(parent) {
 
 
     setAttribute(Qt::WA_NoMousePropagation);
@@ -15,6 +15,7 @@ TouchTextEdit::TouchTextEdit(QString name, QString initial_value, QWidget* paren
 
     quick_widget->rootContext()->setContextProperty("_initialValue", initial_value);
     quick_widget->rootContext()->setContextProperty("_name", name);
+    quick_widget->rootContext()->setContextProperty("_isPassword", is_password);
 
     quick_widget->setSource(QUrl("qrc:/pdf_viewer/touchui/TouchTextEdit.qml"));
 

--- a/pdf_viewer/touchui/TouchTextEdit.h
+++ b/pdf_viewer/touchui/TouchTextEdit.h
@@ -9,7 +9,7 @@
 class TouchTextEdit : public QWidget {
     Q_OBJECT
 public:
-    TouchTextEdit(QString name, QString initial_value, QWidget* parent = nullptr);
+    TouchTextEdit(QString name, QString initial_value, bool is_password, QWidget* parent = nullptr);
     void resizeEvent(QResizeEvent* resize_event) override;
     void keyPressEvent(QKeyEvent* kevent) override;
     void set_text(const std::wstring& txt);

--- a/pdf_viewer/touchui/TouchTextEdit.qml
+++ b/pdf_viewer/touchui/TouchTextEdit.qml
@@ -21,6 +21,7 @@ Rectangle {
         color: "white"
         text: _initialValue
         focus: true
+        echoMode: _isPassword ? TextInput.Password : TextInput.Normal
         wrapMode: TextInput.WrapAnywhere
         onAccepted:{
             root.confirmed(edit.text);


### PR DESCRIPTION
Fixes #1623. With this change, when opening password protected files, the password is shown as dots instead of exposing the actual password in plaintext. 

<img width="645" height="123" alt="image" src="https://github.com/user-attachments/assets/5dfb2bbc-d235-4f17-bd44-af73c5ce81e8" />

I added a mask variable that is set to `true` for the `EnterPasswordCommand` and `false` for others.
When hiding the command line, the type of the field is reset to normal mode.

I tested both the normal and the touch_mode version on linux and found no issues.




