### PR TITLE
fix: "new_window" wont open with two_page geometry

### DIFF
--- a/pdf_viewer/main_widget.cpp
+++ b/pdf_viewer/main_widget.cpp
@@ -6468,7 +6468,7 @@ MainWidget* MainWidget::handle_new_window() {
         input_handler,
         checksummer,
         should_quit);
-    new_widget->open_document(main_document_view->get_state());
+   	new_widget->open_document(main_document_view->get_state().document_path);
     new_widget->show();
     new_widget->apply_window_params_for_one_window_mode();
     new_widget->execute_macro_if_enabled(STARTUP_COMMANDS);


### PR DESCRIPTION
Bug: When a document is opened in two_page mode and "new_window" command is run, the new windows file leans towards the right side as the x coordinate is the center of the window.