### PR TITLE
feat: vims `gv` command

### DIFF
--- a/pdf_viewer/input.cpp
+++ b/pdf_viewer/input.cpp
@@ -2656,6 +2656,17 @@ public:
         return res;
     }
 };
+class PreviousSelectionCommand : public Command{
+public:
+				static inline const std::string cname = "select_previous_selection";
+    static inline const std::string hname = "";
+				PreviousSelectionCommand(MainWidget* w): Command(cname, w){};
+
+				void perform(){
+								widget->select_previous_selection();
+				}
+    bool requires_document() { return true; }
+};
 
 class CommandPaletteCommand : public Command {
 public:
@@ -7143,6 +7154,7 @@ CommandManager::CommandManager(ConfigManager* config_manager) {
     register_command<CopyScreenshotToScratchpad>();
     register_command<CopyScreenshotToClipboard>();
     register_command<AddHighlightCommand>();
+    register_command<PreviousSelectionCommand>();
     register_command<GotoTableOfContentsCommand>();
     register_command<GotoHighlightCommand>();
     register_command<IncreaseFreetextBookmarkFontSizeCommand>();

--- a/pdf_viewer/keys.config
+++ b/pdf_viewer/keys.config
@@ -203,6 +203,8 @@ goto_prev_highlight gNh
 #goto_next_highlight_of_type <unbound>
 #goto_prev_highlight_of_type <unbound>
 
+select_previous_selection gv
+
 # ---------- MARKS ----------
 
 # Mark the current location. After pressing the mark button, you must enter a symbol (a letter from a-z or A-Z).

--- a/pdf_viewer/main_widget.cpp
+++ b/pdf_viewer/main_widget.cpp
@@ -105,6 +105,7 @@ extern "C" void hideWindowTitleBar(WId);
 
 extern int next_window_id;
 
+extern bool VERBOSE;
 extern bool SHOULD_USE_MULTIPLE_MONITORS;
 extern bool MULTILINE_MENUS;
 extern bool SORT_BOOKMARKS_BY_LOCATION;
@@ -2723,6 +2724,12 @@ void MainWidget::handle_left_click(WindowPos click_pos, bool down, bool is_shift
     else {
         selection_end = abs_doc_pos;
 
+        if( main_document_view->selected_character_rects.size()>0 || selection_mode==SelectionMode::Label){
+        
+            set_selection_info(&prev_selection, current_selection);
+            set_selection_info(&current_selection, SelectionInfo{main_document_view, selection_begin, selection_end, selection_mode});
+
+        }
         is_selecting = false;
         is_dragging = false;
 
@@ -5361,6 +5368,7 @@ void MainWidget::add_portal(std::wstring source_path, Portal new_link) {
 }
 
 void MainWidget::handle_keyboard_select(const std::wstring& text) {
+    selection_mode = SelectionMode::Label;
     if (text[0] == '#') {
         // we can select text using window-space coordinates.
         // this is not something that the user should be able to do, but it's useful for scripts.
@@ -5567,7 +5575,11 @@ void MainWidget::set_point_select_mode(bool mode) {
 }
 
 void MainWidget::clear_selected_rect() {
+
+    std::optional<AbsoluteRect> _rect =  opengl_widget->get_selected_rectangle();
     opengl_widget->clear_selected_rectangle();
+
+    set_selection_info(&prev_selection, current_selection);
     //rect_select_mode = false;
     //rect_select_begin = {};
     //rect_select_end = {};
@@ -6129,6 +6141,23 @@ std::wstring MainWidget::handle_add_highlight(char symbol) {
         change_selected_highlight_type(symbol);
         return utf8_decode(doc()->get_highlight_index_uuid(selected_highlight_index));
     }
+}
+
+void MainWidget::select_previous_selection(){
+    if(prev_selection.doc_view != main_document_view)return;
+
+    if(prev_selection.selection_mode != SelectionMode::Line)
+        main_document_view->get_text_selection(prev_selection.begin,
+                prev_selection.end,
+                prev_selection.selection_mode == SelectionMode::Word,
+                main_document_view->selected_character_rects,
+                selected_text);
+    else
+        main_document_view->get_line_selection(prev_selection.begin,
+                prev_selection.end,
+                main_document_view->selected_character_rects,
+                selected_text);
+
 }
 
 void MainWidget::change_selected_highlight_type(char new_type) {
@@ -7068,11 +7097,14 @@ void MainWidget::clear_selection_indicators() {
         selection_begin_indicator->hide();
         selection_end_indicator->hide();
         get_text_selection_buttons()->hide();
-        delete selection_begin_indicator;
-        delete selection_end_indicator;
-        //delete text_selection_buttons;
-        selection_begin_indicator = nullptr;
-        selection_end_indicator = nullptr;
+
+								if(prev_selection_begin_indicator != selection_begin_indicator)
+										delete prev_selection_begin_indicator;
+								if(prev_selection_end_indicator != selection_end_indicator)
+										delete prev_selection_end_indicator;
+
+        prev_selection_begin_indicator = selection_begin_indicator;
+								prev_selection_end_indicator = selection_end_indicator;
         //text_selection_buttons = nullptr;
     }
 }
@@ -12113,4 +12145,11 @@ void MainWidget::select_word_under_cursor() {
         true,
         main_document_view->selected_character_rects,
         selected_text);
+}
+
+void MainWidget::set_selection_info(struct SelectionInfo* select1, struct SelectionInfo select2){
+    select1->doc_view = select2.doc_view;
+    select1->selection_mode = select2.selection_mode;
+    select1->begin = select2.begin;
+    select1->end =select2.end;
 }

--- a/pdf_viewer/main_widget.h
+++ b/pdf_viewer/main_widget.h
@@ -64,7 +64,8 @@ enum class DrawingMode {
 enum class SelectionMode {
     Character,
     Word,
-    Line
+    Line,
+    Label
 };
 
 struct MenuNode {
@@ -134,6 +135,12 @@ enum class PaperDownloadFinishedAction {
     Portal
 };
 
+struct SelectionInfo{
+    DocumentView* doc_view;
+    AbsoluteDocumentPos begin;
+    AbsoluteDocumentPos end;
+    SelectionMode selection_mode;
+};
 
 // if we inherit from QWidget there are problems on high refresh rate smartphone displays
 struct WindowState;
@@ -227,6 +234,9 @@ public:
     // begin/end position of the current text selection
     AbsoluteDocumentPos selection_begin;
     AbsoluteDocumentPos selection_end;
+
+    SelectionInfo prev_selection; 
+    SelectionInfo current_selection; 
 
     // when moving the text selection using keyboard, `selection_begin` and `selection_end`
     // might be out of sync with `selected_text_`. `selected_text_is_dirty` is true when this
@@ -645,6 +655,7 @@ public:
     void handle_show_marks();
     void handle_goto_bookmark_global();
     std::wstring handle_add_highlight(char symbol);
+				void select_previous_selection();
     void handle_goto_highlight();
     void handle_goto_highlight_global();
     void handle_goto_toc();
@@ -701,6 +712,8 @@ public:
     // Text selection indicators in touch mode
     SelectionIndicator* selection_begin_indicator = nullptr;
     SelectionIndicator* selection_end_indicator = nullptr;
+    SelectionIndicator* prev_selection_begin_indicator = nullptr;
+    SelectionIndicator* prev_selection_end_indicator = nullptr;
 
     // When in touch mode, sometimes we use the last touch hold point for some commands
     // for example, if select text button is pressed, we select the text under the last touch hold point
@@ -1045,6 +1058,7 @@ public:
     void select_next_char();
     void unselect_last_char();
     void select_word_under_cursor();
+    void set_selection_info(struct SelectionInfo* select1, struct SelectionInfo select2);
 };
 
 MainWidget* get_window_with_window_id(int window_id);


### PR DESCRIPTION
Command for selecting the previously selected text,
kind of solves #1077 by making reselection easy

(yet to implement the mobile version as of now)

Notes:
- Does not include changes made by `select_next_char` or `unselect_last_char` commands. Is this important? I will have to figure out how to convert AbsoluteRect to AbsoluteDocumentPos then ( idk how to do that ;-; )
- Should there be a command (default keybinding as gV) that does a combination of `select_previous_selection` *and* goto_selected_text?